### PR TITLE
Implement mobile app shell preview with Slate360 branding

### DIFF
--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -81,11 +81,11 @@ export default function MobileShellPreview() {
                       key={idx}
                       className="relative group"
                     >
-                      <div className="h-20 bg-slate-800/50 border border-yellow-500/40 hover:border-yellow-400 rounded-xl flex flex-col items-center justify-center gap-0.5 transition-all hover:bg-slate-800 hover:shadow-md hover:shadow-yellow-400/15">
-                        <div className="p-1.5 bg-slate-700/50 group-hover:bg-slate-600 rounded-lg transition-colors">
-                          <app.icon size={14} className="text-slate-300 group-hover:text-yellow-300" />
+                      <div className="h-20 bg-slate-800/50 border border-slate-700 hover:border-yellow-400 rounded-xl flex flex-col items-center justify-center gap-1 transition-all hover:bg-slate-800">
+                        <div className="p-1.5 bg-slate-700/50 rounded-lg">
+                          <app.icon size={14} className="text-yellow-400" />
                         </div>
-                        <span className="text-xs font-medium text-slate-100 text-center px-0.5 leading-tight">{app.label}</span>
+                        <span className="text-xs font-medium text-slate-300 text-center px-0.5">{app.label}</span>
                         {app.status === "coming" && (
                           <span className="text-xs font-medium text-slate-500 opacity-70 text-center leading-none">Coming<br />Soon</span>
                         )}
@@ -110,7 +110,7 @@ export default function MobileShellPreview() {
                 ].map((item, idx) => (
                   <div
                     key={idx}
-                    className="flex items-start gap-3 p-3 bg-slate-800/50 border border-slate-700 hover:border-cyan-700/60 rounded-lg transition-all cursor-pointer hover:bg-slate-800"
+                    className="flex items-start gap-3 p-3 bg-slate-800/50 border border-slate-700 hover:border-yellow-400 rounded-lg transition-all cursor-pointer hover:bg-slate-800"
                   >
                     <div className="pt-1 flex-shrink-0">
                       {item.type === "review" && <AlertCircle size={14} className="text-yellow-400" />}
@@ -142,7 +142,7 @@ export default function MobileShellPreview() {
                 ].map((action, idx) => (
                   <button
                     key={idx}
-                    className="h-20 bg-slate-800/50 border border-slate-700 hover:border-cyan-700/60 rounded-xl transition-all flex flex-col items-center justify-center gap-1 hover:bg-slate-800"
+                    className="h-20 bg-slate-800/50 border border-slate-700 hover:border-yellow-400 rounded-xl transition-all flex flex-col items-center justify-center gap-1 hover:bg-slate-800"
                   >
                     <div className="p-1.5 bg-slate-700/50 rounded-lg">
                       <action.icon size={14} className="text-yellow-400" />
@@ -158,7 +158,7 @@ export default function MobileShellPreview() {
               <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2 px-1">Pinned</h3>
               <div className="space-y-1">
                 {[1, 2, 3].map((idx) => (
-                  <div key={idx} className="flex items-center gap-2 p-2 bg-slate-800/40 border border-slate-700 hover:border-cyan-700/60 rounded transition-colors cursor-pointer">
+                  <div key={idx} className="flex items-center gap-2 p-2 bg-slate-800/40 border border-slate-700 hover:border-yellow-400 rounded transition-colors cursor-pointer">
                     <Star size={12} className="text-slate-600 flex-shrink-0" fill="currentColor" />
                     <div className="flex-1 min-w-0">
                       <p className="text-xs font-medium text-slate-400">Project</p>
@@ -194,7 +194,7 @@ export default function MobileShellPreview() {
               <button
                 key={idx}
                 className={`flex flex-col items-center justify-center gap-1 py-2 px-2 rounded-lg transition-all text-xs font-medium ${
-                  nav.active ? "text-cyan-300 bg-cyan-950/40" : "text-slate-500 hover:text-slate-400"
+                  nav.active ? "text-yellow-400 bg-slate-800/40" : "text-slate-500 hover:text-slate-400"
                 }`}
               >
                 <nav.icon size={18} />

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -1,26 +1,6 @@
-import { Home, FolderOpen, Files, CheckSquare, User, Search, Bell, Plus, Star, ChevronRight, Zap, MessageSquare, AlertCircle, MapPin, ChevronDown } from "lucide-react";
+import { Home, FolderOpen, Files, CheckSquare, User, Search, Bell, Plus, Star, ChevronRight, MapPin } from "lucide-react";
 
 export default function MobileShellPreview() {
-  const apps = [
-    { label: "Site Walk", icon: MapPin },
-  ];
-
-  // Calculate grid layout based on app count
-  const getGridClass = () => {
-    const count = apps.length;
-    if (count === 1) return "grid grid-cols-1 place-items-center";
-    if (count === 2) return "grid grid-cols-2";
-    if (count === 3) return "grid grid-cols-2";
-    if (count === 4) return "grid grid-cols-2";
-    return "grid grid-cols-2";
-  };
-
-  const workFeedItems = [
-    { label: "Design review requested", source: "Sarah Chen", type: "review", time: "2h ago" },
-    { label: "Contractor uploaded files", source: "Field Team", type: "upload", time: "4h ago" },
-    { label: "Specification update pending", source: "System", type: "submission", time: "1d ago" },
-  ];
-
   return (
     <div className="min-h-screen bg-slate-950 dark flex items-center justify-center p-4">
       {/* Mobile Phone Frame */}
@@ -31,159 +11,105 @@ export default function MobileShellPreview() {
         {/* Main Container */}
         <div className="h-full w-full flex flex-col bg-slate-950 relative">
           {/* Proof Header */}
-          <div className="bg-amber-500/10 border-b border-amber-500/30 px-4 py-3 text-center">
+          <div className="bg-amber-500/10 border-b border-amber-500/30 px-4 py-2 text-center">
             <p className="text-xs font-bold text-amber-500 uppercase tracking-wider">Slate360 Mobile Shell Preview</p>
-            <p className="text-xs text-amber-400 mt-1">Home screen proof</p>
           </div>
 
-          {/* Top Bar - Premium Slate360 Branding */}
+          {/* Top Bar */}
           <div className="flex items-center justify-between px-4 py-3 bg-slate-950 border-b border-slate-800">
-            {/* Logo */}
-            <div className="flex items-center gap-3">
-              <div className="relative w-8 h-8">
-                <svg className="w-full h-full" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <defs>
-                    <linearGradient id="slate360gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                      <stop offset="0%" stopColor="#D4AF37" stopOpacity="1" />
-                      <stop offset="100%" stopColor="#C4A027" stopOpacity="0.8" />
-                    </linearGradient>
-                  </defs>
-                  <path d="M12 2L20 6V10L12 14L4 10V6L12 2Z" fill="url(#slate360gradient)" />
-                  <path d="M12 10L20 14V18L12 22L4 18V14L12 10Z" fill="#D4AF37" />
-                </svg>
-              </div>
-              <span className="text-xs font-bold text-slate-200 tracking-widest hidden sm:inline">SLATE360</span>
+            <div className="flex items-center gap-2">
+              <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 2L20 6V10L12 14L4 10V6L12 2Z" fill="#D4AF37" opacity="0.8" />
+                <path d="M12 10L20 14V18L12 22L4 18V14L12 10Z" fill="#D4AF37" />
+              </svg>
+              <span className="text-xs font-bold text-slate-300 hidden sm:inline">SLATE360</span>
             </div>
-
-            {/* Actions */}
             <div className="flex items-center gap-1">
-              <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors">
-                <Search size={18} className="text-slate-500" />
+              <button className="p-2 hover:bg-slate-900 rounded-lg">
+                <Search size={16} className="text-slate-500" />
               </button>
-              <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors relative">
-                <Bell size={18} className="text-slate-500" />
+              <button className="p-2 hover:bg-slate-900 rounded-lg relative">
+                <Bell size={16} className="text-slate-500" />
                 <span className="absolute top-1 right-1 w-1.5 h-1.5 bg-amber-500 rounded-full" />
               </button>
-              <div className="w-8 h-8 bg-slate-800 rounded-full flex items-center justify-center border border-slate-700">
+              <div className="w-7 h-7 bg-slate-800 rounded-full flex items-center justify-center border border-slate-700">
                 <span className="text-xs font-bold text-slate-300">JD</span>
               </div>
             </div>
           </div>
 
-          {/* Content - Home Screen Only */}
-          <div className="flex-1 overflow-y-auto px-4 py-5 pb-24 space-y-6">
-            {/* SECTION 1: Apps - Premium Grid Container */}
+          {/* Content */}
+          <div className="flex-1 overflow-y-auto px-3 py-3 pb-20 space-y-3">
+            {/* Apps */}
             <div>
-              <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider mb-3">Apps</h3>
-              <div className="p-4 bg-slate-900/40 border border-slate-800 rounded-xl backdrop-blur-sm">
-                <div className={`gap-3 ${getGridClass()}`}>
-                  {apps.map((app, idx) => (
-                    <button
-                      key={idx}
-                      className="w-full max-w-xs"
-                    >
-                      <div className="aspect-square bg-gradient-to-br from-slate-800 to-slate-850 border border-amber-500/30 hover:border-amber-500/60 rounded-lg flex flex-col items-center justify-center gap-2 transition-all hover:shadow-lg hover:shadow-amber-500/20 group hover:bg-slate-800">
-                        <div className="p-2.5 bg-slate-700/50 group-hover:bg-slate-700 rounded-lg transition-colors">
-                          <app.icon size={20} className="text-slate-300 group-hover:text-amber-400" />
-                        </div>
-                        <span className="text-xs font-medium text-slate-200 text-center">{app.label}</span>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-                {apps.length < 4 && (
-                  <button className="w-full mt-3 py-2 text-xs font-medium text-slate-500 hover:text-slate-400 transition-colors border border-dashed border-slate-700 hover:border-slate-600 rounded-lg">
-                    Discover more apps
-                  </button>
-                )}
+              <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider mb-2">Apps</h3>
+              <div className="grid grid-cols-2 gap-2">
+                <button className="aspect-square bg-slate-800 border border-slate-700 hover:border-amber-500/50 rounded-lg flex flex-col items-center justify-center gap-1.5 transition-all">
+                  <MapPin size={16} className="text-slate-400" />
+                  <span className="text-xs font-medium text-slate-300">Site Walk</span>
+                </button>
+                <button className="aspect-square bg-slate-800 border border-slate-700 hover:border-slate-600 rounded-lg flex flex-col items-center justify-center gap-1.5 transition-all">
+                  <Plus size={16} className="text-slate-500" />
+                  <span className="text-xs font-medium text-slate-400">More</span>
+                </button>
               </div>
             </div>
 
-            {/* SECTION 2: Work Feed - Communications Oriented */}
+            {/* Notifications */}
             <div>
-              <div className="flex items-center justify-between mb-3">
-                <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider">Work Feed</h3>
-                <span className="inline-block px-2 py-0.5 text-xs font-semibold bg-slate-800 text-slate-300 rounded">3</span>
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider">Notifications</h3>
+                <span className="text-xs font-semibold text-amber-500">3</span>
               </div>
-              <div className="p-3 bg-slate-900/40 border border-slate-800 rounded-xl overflow-hidden">
-                <div className="space-y-2 max-h-40 overflow-y-auto">
-                  {workFeedItems.map((item, idx) => (
-                    <div
-                      key={idx}
-                      className="flex items-start gap-3 p-2.5 bg-slate-800/40 hover:bg-slate-800/70 rounded-lg transition-colors cursor-pointer border border-transparent hover:border-slate-700"
-                    >
-                      <div className="pt-0.5 flex-shrink-0">
-                        {item.type === "review" && <AlertCircle size={14} className="text-slate-400" />}
-                        {item.type === "upload" && <MessageSquare size={14} className="text-slate-400" />}
-                        {item.type === "submission" && <CheckSquare size={14} className="text-slate-400" />}
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="text-xs font-medium text-slate-200">{item.label}</p>
-                        <div className="flex items-center justify-between mt-0.5">
-                          <p className="text-xs text-slate-500">{item.source}</p>
-                          <p className="text-xs text-slate-600">{item.time}</p>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-
-            {/* SECTION 3: Quick Actions - Premium Compact */}
-            <div>
-              <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider mb-3">Quick Actions</h3>
-              <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
                 {[
-                  { icon: Plus, label: "New Project" },
-                  { icon: Zap, label: "Continue Work" },
-                  { icon: Files, label: "Open Files" },
-                  { icon: MessageSquare, label: "Report & Suggest" },
+                  "Design review requested",
+                  "Field upload pending",
+                  "Specification update",
+                ].map((item, idx) => (
+                  <div key={idx} className="flex items-start gap-2 p-2 bg-slate-800/50 border border-slate-700 hover:bg-slate-800 rounded-lg transition-colors cursor-pointer">
+                    <div className="w-2 h-2 bg-amber-500 rounded-full mt-1.5 flex-shrink-0" />
+                    <p className="text-xs font-medium text-slate-300">{item}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Quick Actions */}
+            <div>
+              <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider mb-2">Quick Actions</h3>
+              <div className="grid grid-cols-2 gap-2">
+                {[
+                  { icon: Plus, label: "New" },
+                  { icon: Files, label: "Files" },
+                  { icon: Star, label: "Pinned" },
+                  { icon: ChevronRight, label: "Browse" },
                 ].map((action, idx) => (
-                  <button
-                    key={idx}
-                    className="p-3 bg-slate-800/50 border border-slate-700 hover:border-slate-600 hover:bg-slate-800 rounded-lg transition-all flex flex-col items-center gap-2"
-                  >
-                    <div className="p-1.5 bg-slate-700/60 rounded-lg">
-                      <action.icon size={16} className="text-slate-300" />
-                    </div>
-                    <span className="text-xs font-medium text-slate-300 text-center">{action.label}</span>
+                  <button key={idx} className="p-2 bg-slate-800/50 border border-slate-700 hover:border-slate-600 rounded-lg flex flex-col items-center gap-1 transition-colors">
+                    <action.icon size={14} className="text-slate-400" />
+                    <span className="text-xs font-medium text-slate-400">{action.label}</span>
                   </button>
                 ))}
               </div>
             </div>
 
-            {/* SECTION 4: Projects - With Subtle Toggle */}
+            {/* Pinned Projects */}
             <div>
-              <div className="flex items-center justify-between mb-3">
-                <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider">Projects</h3>
-                <div className="flex items-center gap-1 p-1 bg-slate-800/50 rounded-lg">
-                  <button className="px-2 py-1 text-xs font-medium text-slate-300 bg-slate-700 rounded transition-colors">
-                    Pinned
-                  </button>
-                  <button className="px-2 py-1 text-xs font-medium text-slate-500 hover:text-slate-400 transition-colors">
-                    All
-                  </button>
-                </div>
-              </div>
-              <div className="p-3 bg-slate-900/40 border border-slate-800 rounded-xl overflow-hidden">
-                <div className="space-y-1.5 max-h-24 overflow-y-auto">
-                  {[1, 2, 3].map((idx) => (
-                    <div key={idx} className="flex items-center gap-2.5 p-2 bg-slate-800/40 hover:bg-slate-800/60 rounded-lg transition-colors cursor-pointer">
-                      <Star size={12} className="text-slate-600 flex-shrink-0" fill="currentColor" />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-xs font-medium text-slate-400">Project name</p>
-                      </div>
-                      <ChevronRight size={12} className="text-slate-600" />
-                    </div>
-                  ))}
-                </div>
+              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Pinned</h3>
+              <div className="space-y-1">
+                {[1, 2].map((idx) => (
+                  <div key={idx} className="flex items-center gap-2 p-2 bg-slate-800/30 border border-slate-800 rounded hover:bg-slate-800/50 transition-colors cursor-pointer">
+                    <Star size={10} className="text-slate-600" fill="currentColor" />
+                    <p className="text-xs text-slate-400">Project</p>
+                    <ChevronRight size={10} className="text-slate-600 ml-auto" />
+                  </div>
+                ))}
               </div>
             </div>
           </div>
 
-          {/* Bottom Navigation - Static */}
-          <div className="absolute bottom-0 left-0 right-0 flex justify-around items-center h-20 bg-slate-950/95 border-t border-amber-500/10 backdrop-blur-sm px-2">
+          {/* Bottom Navigation */}
+          <div className="absolute bottom-0 left-0 right-0 flex justify-around items-center h-16 bg-slate-950/95 border-t border-slate-800 px-2">
             {[
               { icon: Home, label: "Home", active: true },
               { icon: FolderOpen, label: "Projects" },
@@ -193,11 +119,11 @@ export default function MobileShellPreview() {
             ].map((nav, idx) => (
               <button
                 key={idx}
-                className={`flex flex-col items-center justify-center gap-1 py-2 px-2 rounded-lg transition-all text-xs font-medium ${
-                  nav.active ? "text-amber-500 bg-amber-500/10" : "text-slate-500 hover:text-slate-400"
+                className={`flex flex-col items-center justify-center gap-0.5 py-1 px-1 rounded text-xs font-medium ${
+                  nav.active ? "text-amber-500" : "text-slate-500 hover:text-slate-400"
                 }`}
               >
-                <nav.icon size={18} />
+                <nav.icon size={16} />
                 <span className="text-xs">{nav.label}</span>
               </button>
             ))}

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -1,0 +1,374 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Home,
+  FolderOpen,
+  Files,
+  CheckSquare,
+  User,
+  Search,
+  Bell,
+  Plus,
+  Clock,
+  MapPin,
+  MessageSquare,
+  Settings,
+  HelpCircle,
+  Download,
+  BarChart3,
+  ChevronRight,
+  Star,
+  Folder,
+  Archive,
+  Share2,
+  MoreVertical,
+} from "lucide-react";
+
+type Tab = "home" | "projects" | "files" | "tasks" | "account";
+
+export default function MobileShellPreview() {
+  const [activeTab, setActiveTab] = useState<Tab>("home");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [filesContext, setFilesContext] = useState<"root" | "project">("root");
+
+  return (
+    <div className="min-h-screen bg-slate-900 dark overflow-hidden">
+      {/* Mobile Phone Frame Wrapper */}
+      <div className="flex items-center justify-center min-h-screen p-4 dark">
+        <div className="relative w-full max-w-sm bg-slate-950 rounded-3xl shadow-2xl overflow-hidden border-8 border-slate-800" style={{ aspectRatio: "9/19.5" }}>
+          {/* Phone Notch */}
+          <div className="absolute top-0 left-1/2 -translate-x-1/2 w-40 h-7 bg-slate-950 rounded-b-3xl z-50 border-b-2 border-slate-700" />
+
+          {/* Safe Area Container */}
+          <div className="h-full w-full flex flex-col bg-slate-950 relative">
+            {/* ─────── TOP BAR ─────── */}
+            <div className="flex items-center justify-between px-4 pt-8 pb-3 bg-gradient-to-b from-slate-900 to-slate-950 border-b border-slate-800">
+              {/* Logo */}
+              <div className="flex items-center gap-2">
+                <div className="w-6 h-6 bg-amber-500 rounded-lg flex items-center justify-center">
+                  <span className="text-xs font-bold text-slate-950">S</span>
+                </div>
+                <span className="text-sm font-bold text-white hidden xs:inline">Slate360</span>
+              </div>
+
+              {/* Search & Actions */}
+              <div className="flex items-center gap-2">
+                <button className="p-2 hover:bg-slate-800 rounded-lg transition-colors">
+                  <Search size={18} className="text-slate-300" />
+                </button>
+                <button className="p-2 hover:bg-slate-800 rounded-lg transition-colors relative">
+                  <Bell size={18} className="text-slate-300" />
+                  <span className="absolute top-1 right-1 w-2 h-2 bg-amber-500 rounded-full" />
+                </button>
+                <div className="w-8 h-8 bg-gradient-to-br from-amber-400 to-amber-600 rounded-full flex items-center justify-center">
+                  <span className="text-xs font-bold text-slate-950">JD</span>
+                </div>
+              </div>
+            </div>
+
+            {/* ─────── CONTENT AREA ─────── */}
+            <div className="flex-1 overflow-y-auto px-3 py-4 pb-24 scroll-smooth">
+              {/* HOME TAB */}
+              {activeTab === "home" && (
+                <div className="space-y-4">
+                  {/* Search Projects */}
+                  <div className="relative">
+                    <input
+                      type="text"
+                      placeholder="Search projects..."
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      className="w-full px-4 py-2 bg-slate-800 border border-slate-700 rounded-xl text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+                    />
+                  </div>
+
+                  {/* Pinned Projects */}
+                  <div>
+                    <h3 className="text-xs font-semibold text-slate-300 mb-2 uppercase tracking-wider">Pinned Projects</h3>
+                    <div className="space-y-2">
+                      {["Downtown Office Tower", "Riverside Park Condos"].map((project, idx) => (
+                        <div key={idx} className="flex items-center gap-3 p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-colors cursor-pointer">
+                          <Star size={16} className="text-amber-500" fill="currentColor" />
+                          <div className="flex-1 min-w-0">
+                            <p className="text-sm font-medium text-white truncate">{project}</p>
+                            <p className="text-xs text-slate-400">Active • 12 files</p>
+                          </div>
+                          <ChevronRight size={16} className="text-slate-500" />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Quick Actions */}
+                  <div>
+                    <h3 className="text-xs font-semibold text-slate-300 mb-2 uppercase tracking-wider">Quick Actions</h3>
+                    <div className="grid grid-cols-2 gap-2">
+                      {[
+                        { icon: Plus, label: "New Project", color: "from-amber-500 to-amber-600" },
+                        { icon: FolderOpen, label: "Open Projects", color: "from-blue-500 to-blue-600" },
+                        { icon: Files, label: "Open Files", color: "from-purple-500 to-purple-600" },
+                        { icon: Clock, label: "Resume Work", color: "from-emerald-500 to-emerald-600" },
+                      ].map((action, idx) => (
+                        <button
+                          key={idx}
+                          className="p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-all flex flex-col items-center gap-2 group"
+                        >
+                          <div className={`p-2 bg-gradient-to-br ${action.color} rounded-lg group-hover:scale-110 transition-transform`}>
+                            <action.icon size={16} className="text-white" />
+                          </div>
+                          <span className="text-xs font-medium text-slate-300 text-center">{action.label}</span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Notifications & Pending */}
+                  <div>
+                    <h3 className="text-xs font-semibold text-slate-300 mb-2 uppercase tracking-wider">Pending</h3>
+                    <div className="space-y-2">
+                      {[
+                        { title: "RFI #4521 awaiting response", time: "2 days overdue" },
+                        { title: "Submittal review from contractor", time: "In review" },
+                      ].map((item, idx) => (
+                        <div key={idx} className="flex items-start gap-3 p-3 bg-slate-800/50 border border-slate-700 rounded-lg">
+                          <div className="w-2 h-2 bg-amber-500 rounded-full mt-1.5 flex-shrink-0" />
+                          <div className="flex-1 min-w-0">
+                            <p className="text-sm font-medium text-white">{item.title}</p>
+                            <p className="text-xs text-slate-400">{item.time}</p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Apps & Tools */}
+                  <div>
+                    <h3 className="text-xs font-semibold text-slate-300 mb-2 uppercase tracking-wider">Available Apps</h3>
+                    <div className="space-y-2">
+                      {[
+                        { name: "Site Walk", icon: MapPin, color: "bg-orange-500/10 border-orange-500/30" },
+                        { name: "Design Studio", icon: Folder, color: "bg-purple-500/10 border-purple-500/30" },
+                        { name: "Content Studio", icon: Files, color: "bg-pink-500/10 border-pink-500/30" },
+                      ].map((app, idx) => (
+                        <div key={idx} className={`flex items-center gap-3 p-3 border rounded-lg ${app.color} cursor-pointer hover:opacity-80 transition-opacity`}>
+                          <app.icon size={16} className="text-slate-300" />
+                          <span className="text-sm font-medium text-slate-300">{app.name}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* PROJECTS TAB */}
+              {activeTab === "projects" && (
+                <div className="space-y-4">
+                  <div className="relative">
+                    <input
+                      type="text"
+                      placeholder="Search projects..."
+                      className="w-full px-4 py-2 bg-slate-800 border border-slate-700 rounded-xl text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+                    />
+                  </div>
+
+                  <div className="space-y-3">
+                    <div>
+                      <h3 className="text-xs font-semibold text-slate-300 mb-2 uppercase tracking-wider">Pinned</h3>
+                      <div className="flex gap-2 overflow-x-auto pb-2">
+                        {["DTC", "RPC"].map((pin, idx) => (
+                          <div key={idx} className="flex-shrink-0 w-20 aspect-square bg-slate-800 border border-slate-700 rounded-lg flex items-center justify-center">
+                            <Star size={16} className="text-amber-500" fill="currentColor" />
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    {["My Projects", "Team Projects", "Shared / External", "All Accessible"].map((section, idx) => (
+                      <div key={idx}>
+                        <h3 className="text-xs font-semibold text-slate-300 mb-2 uppercase tracking-wider">{section}</h3>
+                        <div className="space-y-2">
+                          {[1, 2].map((item) => (
+                            <div key={item} className="flex items-center justify-between p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-colors cursor-pointer">
+                              <div className="flex items-center gap-3 flex-1 min-w-0">
+                                <div className="w-8 h-8 bg-amber-500/20 rounded flex items-center justify-center">
+                                  <FolderOpen size={14} className="text-amber-500" />
+                                </div>
+                                <div className="min-w-0">
+                                  <p className="text-sm font-medium text-white truncate">Project {section.split(" ")[0]}</p>
+                                  <p className="text-xs text-slate-400">8 files</p>
+                                </div>
+                              </div>
+                              <ChevronRight size={16} className="text-slate-500" />
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+
+                    <button className="w-full flex items-center justify-center gap-2 py-3 bg-amber-500 hover:bg-amber-600 rounded-lg text-sm font-semibold text-slate-950 transition-colors">
+                      <Plus size={16} />
+                      Create Project
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {/* FILES TAB */}
+              {activeTab === "files" && (
+                <div className="space-y-4">
+                  {filesContext === "root" && (
+                    <>
+                      <button
+                        onClick={() => setFilesContext("project")}
+                        className="w-full flex items-center gap-3 p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-colors"
+                      >
+                        <Folder size={18} className="text-amber-500" />
+                        <span className="text-sm font-medium text-white">Projects</span>
+                        <ChevronRight size={16} className="text-slate-500 ml-auto" />
+                      </button>
+
+                      {["General", "Site Walk", "360 Tours", "Design Studio", "Content Studio", "Shared", "Archive / History"].map((folder, idx) => (
+                        <div
+                          key={idx}
+                          className="flex items-center justify-between p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-colors cursor-pointer"
+                        >
+                          <div className="flex items-center gap-3">
+                            <Folder size={18} className="text-slate-400" />
+                            <span className="text-sm font-medium text-white">{folder}</span>
+                          </div>
+                          <ChevronRight size={16} className="text-slate-500" />
+                        </div>
+                      ))}
+                    </>
+                  )}
+
+                  {filesContext === "project" && (
+                    <>
+                      <button
+                        onClick={() => setFilesContext("root")}
+                        className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-amber-500 hover:text-amber-400 transition-colors"
+                      >
+                        <ChevronRight size={16} className="rotate-180" />
+                        Back to Root
+                      </button>
+
+                      <div className="p-3 bg-slate-800/50 border border-slate-700 rounded-lg">
+                        <p className="text-xs text-slate-400 uppercase tracking-wider">Downtown Office Tower</p>
+                        <p className="text-sm font-semibold text-white mt-1">Project Files (24)</p>
+                      </div>
+
+                      {["Drawings", "Specifications", "Permits", "Contracts", "Submittals", "RFIs"].map((file, idx) => (
+                        <div key={idx} className="flex items-center justify-between p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-colors cursor-pointer">
+                          <div className="flex items-center gap-3">
+                            <Files size={18} className="text-slate-400" />
+                            <span className="text-sm font-medium text-white">{file}</span>
+                          </div>
+                          <ChevronRight size={16} className="text-slate-500" />
+                        </div>
+                      ))}
+                    </>
+                  )}
+                </div>
+              )}
+
+              {/* TASKS TAB */}
+              {activeTab === "tasks" && (
+                <div className="space-y-4">
+                  {["My Tasks", "Approvals / Reviews", "Contractor Submissions", "Overdue / At Risk", "Recently Completed"].map((section, idx) => (
+                    <div key={idx}>
+                      <h3 className="text-xs font-semibold text-slate-300 mb-2 uppercase tracking-wider">{section}</h3>
+                      <div className="space-y-2">
+                        {[1, 2].map((task) => (
+                          <div key={task} className="flex items-start gap-3 p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-colors cursor-pointer">
+                            <CheckSquare size={18} className="text-slate-400 mt-0.5" />
+                            <div className="flex-1 min-w-0">
+                              <p className="text-sm font-medium text-white">Task item from {section}</p>
+                              <div className="flex items-center gap-2 mt-1">
+                                <span className="inline-block px-2 py-0.5 text-xs font-medium bg-amber-500/20 text-amber-300 rounded">Due today</span>
+                              </div>
+                            </div>
+                            <ChevronRight size={16} className="text-slate-500" />
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* ACCOUNT TAB */}
+              {activeTab === "account" && (
+                <div className="space-y-4">
+                  {/* Profile Section */}
+                  <div className="p-4 bg-slate-800/50 border border-slate-700 rounded-lg">
+                    <div className="flex items-center gap-3 mb-4">
+                      <div className="w-12 h-12 bg-gradient-to-br from-amber-400 to-amber-600 rounded-full flex items-center justify-center">
+                        <span className="text-sm font-bold text-slate-950">JD</span>
+                      </div>
+                      <div>
+                        <p className="text-sm font-semibold text-white">John Doe</p>
+                        <p className="text-xs text-slate-400">john.doe@slate360.com</p>
+                      </div>
+                    </div>
+                    <button className="w-full py-2 px-3 text-sm font-medium text-amber-500 hover:text-amber-400 transition-colors border border-amber-500/30 rounded-lg">
+                      Edit Profile
+                    </button>
+                  </div>
+
+                  {/* Menu Items */}
+                  {[
+                    { icon: User, label: "Profile & Organization" },
+                    { icon: BarChart3, label: "Plan & Usage" },
+                    { icon: Download, label: "Downloads & Updates" },
+                    { icon: Settings, label: "Settings" },
+                    { icon: HelpCircle, label: "Help & Support" },
+                  ].map((item, idx) => (
+                    <div
+                      key={idx}
+                      className="flex items-center justify-between p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-colors cursor-pointer"
+                    >
+                      <div className="flex items-center gap-3">
+                        <item.icon size={18} className="text-amber-500" />
+                        <span className="text-sm font-medium text-white">{item.label}</span>
+                      </div>
+                      <ChevronRight size={16} className="text-slate-500" />
+                    </div>
+                  ))}
+
+                  <button className="w-full py-3 px-3 text-sm font-medium text-slate-300 hover:text-white bg-slate-800/30 hover:bg-slate-800/50 border border-slate-700 rounded-lg transition-colors">
+                    Sign Out
+                  </button>
+                </div>
+              )}
+            </div>
+
+            {/* ─────── BOTTOM NAVIGATION ─────── */}
+            <div className="absolute bottom-0 left-0 right-0 flex justify-around items-center h-20 bg-gradient-to-t from-slate-950 to-slate-950/50 border-t border-slate-800 px-2 safe-area-inset-bottom">
+              {[
+                { id: "home", icon: Home, label: "Home" },
+                { id: "projects", icon: FolderOpen, label: "Projects" },
+                { id: "files", icon: Files, label: "Files" },
+                { id: "tasks", icon: CheckSquare, label: "Tasks" },
+                { id: "account", icon: User, label: "Account" },
+              ].map((nav) => (
+                <button
+                  key={nav.id}
+                  onClick={() => setActiveTab(nav.id as Tab)}
+                  className={`flex flex-col items-center justify-center gap-1 py-2 px-3 rounded-lg transition-all ${
+                    activeTab === nav.id
+                      ? "text-amber-500 bg-amber-500/10"
+                      : "text-slate-400 hover:text-slate-300 hover:bg-slate-800/50"
+                  }`}
+                >
+                  <nav.icon size={20} />
+                  <span className="text-xs font-medium">{nav.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -55,8 +55,8 @@ export default function MobileShellPreview() {
             {/* PRIORITY 1: Subscribed Apps - Premium Adaptive Grid */}
             <div>
               <h3 className="text-xs font-bold text-amber-300 uppercase tracking-wider mb-2 px-1">Apps</h3>
-              <div className="flex justify-center">
-                <div className="grid gap-2 w-full max-w-[224px]" style={{ gridTemplateColumns: "repeat(2, 1fr)" }}>
+              <div className="flex justify-center w-full">
+                <div className="grid gap-x-3 gap-y-3 w-full max-w-[202px]" style={{ gridTemplateColumns: "repeat(2, 1fr)" }}>
                   {[
                     { label: "Site Walk", icon: MapPin, status: "live" },
                     { label: "360 Tours", icon: Camera, status: "coming" },
@@ -69,11 +69,11 @@ export default function MobileShellPreview() {
                     >
                       <div className="aspect-square bg-slate-800/40 border border-slate-700 hover:border-amber-500/60 rounded-lg flex flex-col items-center justify-center gap-0.5 transition-all hover:bg-slate-800/80 hover:shadow-md hover:shadow-amber-500/20">
                         <div className="p-1.5 bg-slate-700/50 group-hover:bg-slate-700 rounded-md transition-colors">
-                          <app.icon size={12} className="text-slate-300 group-hover:text-amber-300" />
+                          <app.icon size={11} className="text-slate-300 group-hover:text-amber-300" />
                         </div>
                         <span className="text-xs font-medium text-slate-100 text-center px-0.5 leading-tight">{app.label}</span>
                         {app.status === "coming" && (
-                          <span className="text-xs font-medium text-slate-500 opacity-75 text-center leading-none">Coming</span>
+                          <span className="text-xs font-medium text-slate-500 opacity-75 text-center leading-none">Coming<br />Soon</span>
                         )}
                       </div>
                     </button>

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -56,7 +56,7 @@ export default function MobileShellPreview() {
             <div>
               <h3 className="text-xs font-bold text-amber-300 uppercase tracking-wider mb-2 px-1">Apps</h3>
               <div className="flex justify-center">
-                <div className="grid gap-2.5 w-full max-w-xs" style={{ gridTemplateColumns: "repeat(2, 1fr)" }}>
+                <div className="grid gap-2 w-full max-w-[224px]" style={{ gridTemplateColumns: "repeat(2, 1fr)" }}>
                   {[
                     { label: "Site Walk", icon: MapPin, status: "live" },
                     { label: "360 Tours", icon: Camera, status: "coming" },
@@ -67,11 +67,11 @@ export default function MobileShellPreview() {
                       key={idx}
                       className="relative group"
                     >
-                      <div className="aspect-square bg-slate-800/40 border border-slate-700 hover:border-amber-500/60 rounded-lg flex flex-col items-center justify-center gap-1 transition-all hover:bg-slate-800/80 hover:shadow-md hover:shadow-amber-500/20">
-                        <div className="p-2 bg-slate-700/50 group-hover:bg-slate-700 rounded-lg transition-colors">
-                          <app.icon size={16} className="text-slate-300 group-hover:text-amber-300" />
+                      <div className="aspect-square bg-slate-800/40 border border-slate-700 hover:border-amber-500/60 rounded-lg flex flex-col items-center justify-center gap-0.5 transition-all hover:bg-slate-800/80 hover:shadow-md hover:shadow-amber-500/20">
+                        <div className="p-1.5 bg-slate-700/50 group-hover:bg-slate-700 rounded-md transition-colors">
+                          <app.icon size={12} className="text-slate-300 group-hover:text-amber-300" />
                         </div>
-                        <span className="text-xs font-medium text-slate-100 text-center px-0.5">{app.label}</span>
+                        <span className="text-xs font-medium text-slate-100 text-center px-0.5 leading-tight">{app.label}</span>
                         {app.status === "coming" && (
                           <span className="text-xs font-medium text-slate-500 opacity-75 text-center leading-none">Coming</span>
                         )}

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -1,4 +1,4 @@
-import { Home, FolderOpen, Files, CheckSquare, User, Search, Bell, Plus, Star, ChevronRight } from "lucide-react";
+import { Home, FolderOpen, Files, CheckSquare, User, Search, Bell, Plus, Star, ChevronRight, Zap, MessageSquare, AlertCircle } from "lucide-react";
 
 export default function MobileShellPreview() {
   return (
@@ -43,27 +43,88 @@ export default function MobileShellPreview() {
           </div>
 
           {/* Content - Home Screen Only */}
-          <div className="flex-1 overflow-y-auto px-3 py-4 pb-24 space-y-4">
-            {/* Search */}
-            <div className="relative">
-              <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" />
-              <input
-                type="text"
-                placeholder="Find projects..."
-                className="w-full pl-10 pr-4 py-2.5 bg-slate-900/80 border border-slate-800 rounded-xl text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50"
-              />
+          <div className="flex-1 overflow-y-auto px-3 py-4 pb-24 space-y-5">
+            {/* PRIORITY 1: Subscribed Apps / App Launcher */}
+            <div>
+              <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider mb-3 px-1">Subscribed Apps</h3>
+              <div className="grid grid-cols-3 gap-2">
+                {[
+                  { label: "360 Tours", icon: "360" },
+                  { label: "Design Studio", icon: "DSN" },
+                  { label: "Content Studio", icon: "CNT" },
+                ].map((app, idx) => (
+                  <button
+                    key={idx}
+                    className="aspect-square bg-gradient-to-br from-slate-800 to-slate-900 border border-slate-700 hover:border-amber-500/50 rounded-xl flex flex-col items-center justify-center gap-2 transition-all hover:shadow-lg hover:shadow-amber-500/20"
+                  >
+                    <div className="w-8 h-8 bg-amber-500/20 rounded-lg flex items-center justify-center">
+                      <span className="text-xs font-bold text-amber-500">{app.icon}</span>
+                    </div>
+                    <span className="text-xs font-medium text-slate-200 text-center px-1">{app.label}</span>
+                  </button>
+                ))}
+              </div>
             </div>
 
-            {/* Pinned Projects */}
+            {/* PRIORITY 2: Notifications & Active Work Feed */}
             <div>
-              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Pinned</h3>
+              <div className="flex items-center justify-between mb-3 px-1">
+                <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider">Active Items</h3>
+                <span className="inline-block px-2 py-0.5 text-xs font-semibold bg-amber-500/30 text-amber-300 rounded">2</span>
+              </div>
+              <div className="space-y-2">
+                {[
+                  { label: "Review pending", type: "review" },
+                  { label: "Field update awaiting response", type: "update" },
+                ].map((item, idx) => (
+                  <div
+                    key={idx}
+                    className="flex items-start gap-3 p-3 bg-slate-900/80 border border-amber-500/30 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer"
+                  >
+                    <AlertCircle size={14} className="text-amber-500 mt-0.5 flex-shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-slate-200">{item.label}</p>
+                      <p className="text-xs text-slate-400 mt-0.5">Action required</p>
+                    </div>
+                    <ChevronRight size={14} className="text-slate-600" />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* PRIORITY 3: Quick Actions (Workflow-Driven) */}
+            <div>
+              <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider mb-3 px-1">Quick Actions</h3>
+              <div className="grid grid-cols-2 gap-3">
+                {[
+                  { icon: Plus, label: "New Project", color: "bg-emerald-500/20 hover:bg-emerald-500/30" },
+                  { icon: Zap, label: "Continue Work", color: "bg-blue-500/20 hover:bg-blue-500/30" },
+                  { icon: Files, label: "Open Files", color: "bg-purple-500/20 hover:bg-purple-500/30" },
+                  { icon: MessageSquare, label: "Report / Suggest", color: "bg-slate-700/50 hover:bg-slate-700/70" },
+                ].map((action, idx) => (
+                  <button
+                    key={idx}
+                    className={`p-3 bg-slate-900/60 border border-slate-800 rounded-lg transition-all flex flex-col items-center gap-2 hover:shadow-md`}
+                  >
+                    <div className={`p-2 rounded-lg transition-colors ${action.color}`}>
+                      <action.icon size={16} className="text-slate-100" />
+                    </div>
+                    <span className="text-xs font-medium text-slate-300 text-center">{action.label}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* PRIORITY 4: Pinned Projects (Lower Priority) */}
+            <div>
+              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Pinned Projects</h3>
               <div className="space-y-2">
                 {[1, 2].map((idx) => (
                   <div key={idx} className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer">
                     <div className="flex items-center gap-3">
-                      <Star size={14} className="text-amber-500 flex-shrink-0" fill="currentColor" />
+                      <Star size={14} className="text-slate-600 flex-shrink-0" fill="currentColor" />
                       <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-slate-200">Project</p>
+                        <p className="text-sm font-medium text-slate-300">Project</p>
                         <p className="text-xs text-slate-500">Multiple files</p>
                       </div>
                       <ChevronRight size={14} className="text-slate-600" />
@@ -73,60 +134,16 @@ export default function MobileShellPreview() {
               </div>
             </div>
 
-            {/* Quick Actions */}
+            {/* PRIORITY 5: Quick Search / Browse */}
             <div>
-              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Quick Access</h3>
-              <div className="grid grid-cols-2 gap-3">
-                {[
-                  { icon: Plus, label: "New Project" },
-                  { icon: FolderOpen, label: "Open" },
-                  { icon: Files, label: "Files" },
-                  { icon: Home, label: "Recent" },
-                ].map((action, idx) => (
-                  <button
-                    key={idx}
-                    className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-all flex flex-col items-center gap-2"
-                  >
-                    <div className="p-2 bg-amber-500/20 rounded-lg">
-                      <action.icon size={16} className="text-amber-500" />
-                    </div>
-                    <span className="text-xs font-medium text-slate-300 text-center">{action.label}</span>
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {/* Pending */}
-            <div>
-              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Pending</h3>
-              <div className="space-y-2">
-                {[1, 2].map((idx) => (
-                  <div key={idx} className="flex items-start gap-3 p-3 bg-slate-900/60 border border-slate-800 rounded-lg">
-                    <div className="w-2 h-2 bg-amber-500 rounded-full mt-1.5 flex-shrink-0" />
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium text-slate-200">Pending item</p>
-                      <p className="text-xs text-slate-500">Action required</p>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            {/* Explore/Apps */}
-            <div>
-              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Explore</h3>
-              <div className="space-y-2">
-                {["360 Tours", "Design Studio", "Content Studio"].map((app, idx) => (
-                  <div key={idx} className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-3">
-                        <div className="w-2 h-2 bg-amber-500 rounded-full" />
-                        <span className="text-sm font-medium text-slate-300">{app}</span>
-                      </div>
-                      <ChevronRight size={14} className="text-slate-600" />
-                    </div>
-                  </div>
-                ))}
+              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Find & Browse</h3>
+              <div className="relative">
+                <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" />
+                <input
+                  type="text"
+                  placeholder="Search projects, files..."
+                  className="w-full pl-10 pr-4 py-2.5 bg-slate-900/80 border border-slate-800 rounded-xl text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50"
+                />
               </div>
             </div>
           </div>

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -1,4 +1,4 @@
-import { Home, FolderOpen, Files, CheckSquare, User, Search, Bell, Plus, Star, ChevronRight, Zap, MessageSquare, AlertCircle } from "lucide-react";
+import { Home, FolderOpen, Files, CheckSquare, User, Search, Bell, Plus, Star, ChevronRight, Zap, MessageSquare, AlertCircle, MapPin, Camera, Palette, BookOpen } from "lucide-react";
 
 export default function MobileShellPreview() {
   return (
@@ -16,19 +16,27 @@ export default function MobileShellPreview() {
             <p className="text-xs text-amber-400 mt-1">Home screen proof</p>
           </div>
 
-          {/* Top Bar */}
-          <div className="flex items-center justify-between px-4 py-3 bg-slate-950 border-b border-slate-900/50">
-            {/* Logo */}
-            <div className="flex items-center gap-2">
-              <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M12 2L20 6V10L12 14L4 10V6L12 2Z" fill="#D4AF37" opacity="0.8" />
-                <path d="M12 10L20 14V18L12 22L4 18V14L12 10Z" fill="#D4AF37" />
-              </svg>
-              <span className="text-xs font-bold text-slate-300 tracking-widest hidden sm:inline">SLATE360</span>
+          {/* Top Bar - Enhanced Branding */}
+          <div className="flex items-center justify-between px-4 py-3 bg-slate-950 border-b border-amber-500/20">
+            {/* Logo - Stronger Slate360 Branding */}
+            <div className="flex items-center gap-3">
+              <div className="relative w-8 h-8">
+                <svg className="w-full h-full" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <defs>
+                    <linearGradient id="slate360gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                      <stop offset="0%" stopColor="#D4AF37" stopOpacity="1" />
+                      <stop offset="100%" stopColor="#C4A027" stopOpacity="0.8" />
+                    </linearGradient>
+                  </defs>
+                  <path d="M12 2L20 6V10L12 14L4 10V6L12 2Z" fill="url(#slate360gradient)" />
+                  <path d="M12 10L20 14V18L12 22L4 18V14L12 10Z" fill="#D4AF37" />
+                </svg>
+              </div>
+              <span className="text-xs font-bold text-amber-300 tracking-widest hidden sm:inline">SLATE360</span>
             </div>
 
             {/* Actions */}
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1">
               <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors">
                 <Search size={18} className="text-slate-400" />
               </button>
@@ -36,78 +44,90 @@ export default function MobileShellPreview() {
                 <Bell size={18} className="text-slate-400" />
                 <span className="absolute top-1 right-1 w-1.5 h-1.5 bg-amber-500 rounded-full" />
               </button>
-              <div className="w-8 h-8 bg-slate-800 rounded-full flex items-center justify-center border border-slate-700">
+              <div className="w-8 h-8 bg-slate-800 rounded-full flex items-center justify-center border border-amber-500/50">
                 <span className="text-xs font-bold text-amber-500">JD</span>
               </div>
             </div>
           </div>
 
           {/* Content - Home Screen Only */}
-          <div className="flex-1 overflow-y-auto px-3 py-4 pb-24 space-y-5">
-            {/* PRIORITY 1: Subscribed Apps / App Launcher */}
+          <div className="flex-1 overflow-y-auto px-3 py-4 pb-24 space-y-6">
+            {/* PRIORITY 1: Subscribed Apps - Horizontal Scrollable Launcher */}
             <div>
-              <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider mb-3 px-1">Subscribed Apps</h3>
-              <div className="grid grid-cols-3 gap-2">
+              <h3 className="text-xs font-bold text-amber-300 uppercase tracking-wider mb-3 px-1">Apps</h3>
+              <div className="flex gap-3 overflow-x-auto pb-2 -mx-3 px-3 snap-x snap-mandatory">
                 {[
-                  { label: "360 Tours", icon: "360" },
-                  { label: "Design Studio", icon: "DSN" },
-                  { label: "Content Studio", icon: "CNT" },
+                  { label: "Site Walk", icon: MapPin, accent: "from-orange-600 to-orange-700" },
+                  { label: "360 Tours", icon: Camera, accent: "from-cyan-600 to-cyan-700" },
+                  { label: "Design Studio", icon: Palette, accent: "from-purple-600 to-purple-700" },
+                  { label: "Content Studio", icon: BookOpen, accent: "from-emerald-600 to-emerald-700" },
                 ].map((app, idx) => (
                   <button
                     key={idx}
-                    className="aspect-square bg-gradient-to-br from-slate-800 to-slate-900 border border-slate-700 hover:border-amber-500/50 rounded-xl flex flex-col items-center justify-center gap-2 transition-all hover:shadow-lg hover:shadow-amber-500/20"
+                    className="flex-shrink-0 w-28 aspect-square snap-center"
                   >
-                    <div className="w-8 h-8 bg-amber-500/20 rounded-lg flex items-center justify-center">
-                      <span className="text-xs font-bold text-amber-500">{app.icon}</span>
+                    <div className={`h-full w-full bg-gradient-to-br ${app.accent} border border-yellow-600/30 hover:border-amber-500 rounded-xl flex flex-col items-center justify-center gap-2 transition-all hover:shadow-lg hover:shadow-amber-500/30 group`}>
+                      <div className="p-2 bg-white/10 group-hover:bg-white/20 rounded-lg transition-colors">
+                        <app.icon size={18} className="text-white" />
+                      </div>
+                      <span className="text-xs font-semibold text-white text-center px-1 line-clamp-2">{app.label}</span>
                     </div>
-                    <span className="text-xs font-medium text-slate-200 text-center px-1">{app.label}</span>
                   </button>
                 ))}
               </div>
+              <p className="text-xs text-slate-500 mt-2 px-1">Swipe to see more</p>
             </div>
 
-            {/* PRIORITY 2: Notifications & Active Work Feed */}
+            {/* PRIORITY 2: Communications & Workflow Feed */}
             <div>
               <div className="flex items-center justify-between mb-3 px-1">
-                <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider">Active Items</h3>
-                <span className="inline-block px-2 py-0.5 text-xs font-semibold bg-amber-500/30 text-amber-300 rounded">2</span>
+                <h3 className="text-xs font-bold text-amber-300 uppercase tracking-wider">Notifications</h3>
+                <span className="inline-block px-2 py-0.5 text-xs font-semibold bg-amber-500 text-slate-950 rounded-sm">3</span>
               </div>
               <div className="space-y-2">
                 {[
-                  { label: "Review pending", type: "review" },
-                  { label: "Field update awaiting response", type: "update" },
+                  { label: "Design review requested", source: "Sarah Chen", type: "review", time: "2h ago" },
+                  { label: "Contractor uploaded files", source: "Field Team", type: "upload", time: "4h ago" },
+                  { label: "Specification update pending", source: "System", type: "submission", time: "1d ago" },
                 ].map((item, idx) => (
                   <div
                     key={idx}
-                    className="flex items-start gap-3 p-3 bg-slate-900/80 border border-amber-500/30 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer"
+                    className="flex items-start gap-3 p-3 bg-slate-900/60 border border-slate-800 hover:bg-slate-800/80 hover:border-amber-500/40 transition-all cursor-pointer"
                   >
-                    <AlertCircle size={14} className="text-amber-500 mt-0.5 flex-shrink-0" />
+                    <div className="pt-1 flex-shrink-0">
+                      {item.type === "review" && <AlertCircle size={14} className="text-amber-500" />}
+                      {item.type === "upload" && <MessageSquare size={14} className="text-cyan-400" />}
+                      {item.type === "submission" && <CheckSquare size={14} className="text-emerald-400" />}
+                    </div>
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-medium text-slate-200">{item.label}</p>
-                      <p className="text-xs text-slate-400 mt-0.5">Action required</p>
+                      <div className="flex items-center justify-between mt-1">
+                        <p className="text-xs text-slate-500">{item.source}</p>
+                        <p className="text-xs text-slate-600">{item.time}</p>
+                      </div>
                     </div>
-                    <ChevronRight size={14} className="text-slate-600" />
+                    <ChevronRight size={14} className="text-slate-600 flex-shrink-0 mt-1" />
                   </div>
                 ))}
               </div>
             </div>
 
-            {/* PRIORITY 3: Quick Actions (Workflow-Driven) */}
+            {/* PRIORITY 3: Quick Actions - Entitlement Aware */}
             <div>
-              <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider mb-3 px-1">Quick Actions</h3>
+              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Quick Actions</h3>
               <div className="grid grid-cols-2 gap-3">
                 {[
-                  { icon: Plus, label: "New Project", color: "bg-emerald-500/20 hover:bg-emerald-500/30" },
-                  { icon: Zap, label: "Continue Work", color: "bg-blue-500/20 hover:bg-blue-500/30" },
-                  { icon: Files, label: "Open Files", color: "bg-purple-500/20 hover:bg-purple-500/30" },
-                  { icon: MessageSquare, label: "Report / Suggest", color: "bg-slate-700/50 hover:bg-slate-700/70" },
+                  { icon: Plus, label: "New Project" },
+                  { icon: Zap, label: "Continue Work" },
+                  { icon: Files, label: "Open Files" },
+                  { icon: MessageSquare, label: "Report & Suggest" },
                 ].map((action, idx) => (
                   <button
                     key={idx}
-                    className={`p-3 bg-slate-900/60 border border-slate-800 rounded-lg transition-all flex flex-col items-center gap-2 hover:shadow-md`}
+                    className="p-3 bg-slate-900/60 border border-slate-800 hover:border-amber-500/50 rounded-lg transition-all flex flex-col items-center gap-2 hover:bg-slate-800/80 hover:shadow-md"
                   >
-                    <div className={`p-2 rounded-lg transition-colors ${action.color}`}>
-                      <action.icon size={16} className="text-slate-100" />
+                    <div className="p-2 bg-amber-500/20 rounded-lg">
+                      <action.icon size={16} className="text-amber-300" />
                     </div>
                     <span className="text-xs font-medium text-slate-300 text-center">{action.label}</span>
                   </button>
@@ -115,41 +135,37 @@ export default function MobileShellPreview() {
               </div>
             </div>
 
-            {/* PRIORITY 4: Pinned Projects (Lower Priority) */}
-            <div>
-              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Pinned Projects</h3>
-              <div className="space-y-2">
-                {[1, 2].map((idx) => (
-                  <div key={idx} className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer">
-                    <div className="flex items-center gap-3">
-                      <Star size={14} className="text-slate-600 flex-shrink-0" fill="currentColor" />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-slate-300">Project</p>
-                        <p className="text-xs text-slate-500">Multiple files</p>
-                      </div>
-                      <ChevronRight size={14} className="text-slate-600" />
+            {/* PRIORITY 4: Pinned Projects - Lower Prominence */}
+            <div className="pt-2">
+              <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2 px-1">Pinned</h3>
+              <div className="space-y-1">
+                {[1, 2, 3].map((idx) => (
+                  <div key={idx} className="flex items-center gap-2 p-2 bg-slate-900/40 border border-slate-800/50 hover:bg-slate-800/60 transition-colors cursor-pointer rounded">
+                    <Star size={12} className="text-slate-600 flex-shrink-0" fill="currentColor" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xs font-medium text-slate-400">Project</p>
                     </div>
+                    <ChevronRight size={12} className="text-slate-700" />
                   </div>
                 ))}
               </div>
             </div>
 
-            {/* PRIORITY 5: Quick Search / Browse */}
-            <div>
-              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Find & Browse</h3>
+            {/* PRIORITY 5: Quick Search */}
+            <div className="pt-2">
               <div className="relative">
-                <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" />
+                <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-600" />
                 <input
                   type="text"
-                  placeholder="Search projects, files..."
-                  className="w-full pl-10 pr-4 py-2.5 bg-slate-900/80 border border-slate-800 rounded-xl text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50"
+                  placeholder="Search..."
+                  className="w-full pl-10 pr-4 py-2 bg-slate-900/40 border border-slate-800/50 rounded-lg text-xs text-slate-300 placeholder:text-slate-600 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
                 />
               </div>
             </div>
           </div>
 
           {/* Bottom Navigation - Static */}
-          <div className="absolute bottom-0 left-0 right-0 flex justify-around items-center h-20 bg-slate-950/95 border-t border-slate-900/50 backdrop-blur-sm px-2">
+          <div className="absolute bottom-0 left-0 right-0 flex justify-around items-center h-20 bg-slate-950/95 border-t border-amber-500/10 backdrop-blur-sm px-2">
             {[
               { icon: Home, label: "Home", active: true },
               { icon: FolderOpen, label: "Projects" },

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -30,13 +30,13 @@ export default function MobileShellPreview() {
         {/* Main Container */}
         <div className="h-full w-full flex flex-col bg-slate-950 relative">
           {/* Proof Header */}
-          <div className="bg-yellow-500/10 border-b border-yellow-500/30 px-4 py-3 text-center">
-            <p className="text-xs font-bold text-yellow-500 uppercase tracking-wider">Slate360 Mobile Shell Preview</p>
-            <p className="text-xs text-yellow-400 mt-1">Home screen proof</p>
+          <div className="bg-amber-500/10 border-b border-amber-500/30 px-4 py-3 text-center">
+            <p className="text-xs font-bold text-amber-500 uppercase tracking-wider">Slate360 Mobile Shell Preview</p>
+            <p className="text-xs text-amber-400 mt-1">Home screen proof</p>
           </div>
 
           {/* Top Bar - Enhanced Branding */}
-          <div className="flex items-center justify-between px-4 py-3 bg-slate-950 border-b border-yellow-500/20">
+          <div className="flex items-center justify-between px-4 py-3 bg-slate-950 border-b border-amber-500/20">
             {/* Logo */}
             <div className="flex items-center gap-3">
               <div className="relative w-8 h-8">
@@ -51,7 +51,7 @@ export default function MobileShellPreview() {
                   <path d="M12 10L20 14V18L12 22L4 18V14L12 10Z" fill="#FBBF24" />
                 </svg>
               </div>
-              <span className="text-xs font-bold text-yellow-300 tracking-widest hidden sm:inline">SLATE360</span>
+              <span className="text-xs font-bold text-amber-300 tracking-widest hidden sm:inline">SLATE360</span>
             </div>
 
             {/* Actions */}
@@ -61,10 +61,10 @@ export default function MobileShellPreview() {
               </button>
               <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors relative">
                 <Bell size={18} className="text-slate-400" />
-                <span className="absolute top-1 right-1 w-1.5 h-1.5 bg-yellow-400 rounded-full" />
+                <span className="absolute top-1 right-1 w-1.5 h-1.5 bg-amber-400 rounded-full" />
               </button>
-              <div className="w-8 h-8 bg-slate-800 rounded-full flex items-center justify-center border border-yellow-400/50">
-                <span className="text-xs font-bold text-yellow-400">JD</span>
+              <div className="w-8 h-8 bg-slate-800 rounded-full flex items-center justify-center border border-amber-400/50">
+                <span className="text-xs font-bold text-amber-400">JD</span>
               </div>
             </div>
           </div>
@@ -73,7 +73,7 @@ export default function MobileShellPreview() {
           <div className="flex-1 overflow-y-auto px-3 py-4 pb-24 space-y-6">
             {/* PRIORITY 1: Subscribed Apps - Premium Adaptive Grid */}
             <div>
-              <h3 className="text-xs font-bold text-yellow-300 uppercase tracking-wider mb-2 px-1">Apps</h3>
+              <h3 className="text-xs font-bold text-amber-300 uppercase tracking-wider mb-2 px-1">Apps</h3>
               <div className="flex justify-center w-full">
                 <div className={`grid gap-x-3 gap-y-2 w-full ${gridLayout.cols} ${gridLayout.maxW}`}>
                   {apps.map((app, idx) => (
@@ -81,13 +81,13 @@ export default function MobileShellPreview() {
                       key={idx}
                       className="relative group"
                     >
-                      <div className="h-20 bg-slate-800/50 border border-slate-700 hover:border-yellow-400 rounded-xl flex flex-col items-center justify-center gap-1 transition-all hover:bg-slate-800">
-                        <div className="p-1.5 bg-slate-700/50 rounded-lg">
-                          <app.icon size={14} className="text-yellow-400" />
+                      <div className="h-16 bg-slate-800/50 border border-slate-700 hover:border-amber-500 rounded-xl flex flex-col items-center justify-center gap-0.5 transition-all hover:bg-slate-800">
+                        <div className="p-1 bg-slate-700/50 rounded-md">
+                          <app.icon size={12} className="text-amber-500" />
                         </div>
-                        <span className="text-xs font-medium text-slate-300 text-center px-0.5">{app.label}</span>
+                        <span className="text-xs font-medium text-slate-300 text-center px-0.5 line-clamp-2">{app.label}</span>
                         {app.status === "coming" && (
-                          <span className="text-xs font-medium text-slate-500 opacity-70 text-center leading-none">Coming<br />Soon</span>
+                          <span className="text-xs font-medium text-slate-500 opacity-60 text-center leading-tight" style={{fontSize: "9px"}}>Coming Soon</span>
                         )}
                       </div>
                     </button>
@@ -100,7 +100,7 @@ export default function MobileShellPreview() {
             <div>
               <div className="flex items-center justify-between mb-2 px-1">
                 <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider">Notifications</h3>
-                <span className="inline-block px-2 py-0.5 text-xs font-semibold bg-yellow-500/90 text-slate-950 rounded-sm">3</span>
+                <span className="inline-block px-2 py-0.5 text-xs font-semibold bg-amber-500/90 text-slate-950 rounded-sm">3</span>
               </div>
               <div className="space-y-2">
                 {[
@@ -110,12 +110,12 @@ export default function MobileShellPreview() {
                 ].map((item, idx) => (
                   <div
                     key={idx}
-                    className="flex items-start gap-3 p-3 bg-slate-800/50 border border-slate-700 hover:border-yellow-400 rounded-lg transition-all cursor-pointer hover:bg-slate-800"
+                    className="flex items-start gap-3 p-3 bg-slate-800/50 border border-slate-700 hover:border-amber-500 rounded-lg transition-all cursor-pointer hover:bg-slate-800"
                   >
                     <div className="pt-1 flex-shrink-0">
-                      {item.type === "review" && <AlertCircle size={14} className="text-yellow-400" />}
-                      {item.type === "upload" && <MessageSquare size={14} className="text-yellow-400" />}
-                      {item.type === "submission" && <CheckSquare size={14} className="text-yellow-400" />}
+                      {item.type === "review" && <AlertCircle size={14} className="text-amber-500" />}
+                      {item.type === "upload" && <MessageSquare size={14} className="text-amber-500" />}
+                      {item.type === "submission" && <CheckSquare size={14} className="text-amber-500" />}
                     </div>
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-medium text-slate-200">{item.label}</p>
@@ -142,10 +142,10 @@ export default function MobileShellPreview() {
                 ].map((action, idx) => (
                   <button
                     key={idx}
-                    className="h-20 bg-slate-800/50 border border-slate-700 hover:border-yellow-400 rounded-xl transition-all flex flex-col items-center justify-center gap-1 hover:bg-slate-800"
+                    className="h-20 bg-slate-800/50 border border-slate-700 hover:border-amber-500 rounded-xl transition-all flex flex-col items-center justify-center gap-1 hover:bg-slate-800"
                   >
                     <div className="p-1.5 bg-slate-700/50 rounded-lg">
-                      <action.icon size={14} className="text-yellow-400" />
+                      <action.icon size={14} className="text-amber-500" />
                     </div>
                     <span className="text-xs font-medium text-slate-300 text-center px-0.5">{action.label}</span>
                   </button>
@@ -158,7 +158,7 @@ export default function MobileShellPreview() {
               <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2 px-1">Pinned</h3>
               <div className="space-y-1">
                 {[1, 2, 3].map((idx) => (
-                  <div key={idx} className="flex items-center gap-2 p-2 bg-slate-800/40 border border-slate-700 hover:border-yellow-400 rounded transition-colors cursor-pointer">
+                  <div key={idx} className="flex items-center gap-2 p-2 bg-slate-800/40 border border-slate-700 hover:border-amber-500 rounded transition-colors cursor-pointer">
                     <Star size={12} className="text-slate-600 flex-shrink-0" fill="currentColor" />
                     <div className="flex-1 min-w-0">
                       <p className="text-xs font-medium text-slate-400">Project</p>
@@ -176,7 +176,7 @@ export default function MobileShellPreview() {
                 <input
                   type="text"
                   placeholder="Search..."
-                  className="w-full pl-10 pr-4 py-2 bg-slate-800/40 border border-slate-700 rounded-lg text-xs text-slate-300 placeholder:text-slate-600 focus:outline-none focus:ring-2 focus:ring-yellow-500/50 focus:border-transparent"
+                  className="w-full pl-10 pr-4 py-2 bg-slate-800/40 border border-slate-700 rounded-lg text-xs text-slate-300 placeholder:text-slate-600 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
                 />
               </div>
             </div>
@@ -194,7 +194,7 @@ export default function MobileShellPreview() {
               <button
                 key={idx}
                 className={`flex flex-col items-center justify-center gap-1 py-2 px-2 rounded-lg transition-all text-xs font-medium ${
-                  nav.active ? "text-yellow-400 bg-slate-800/40" : "text-slate-500 hover:text-slate-400"
+                  nav.active ? "text-amber-500 bg-slate-800/40" : "text-slate-500 hover:text-slate-400"
                 }`}
               >
                 <nav.icon size={18} />

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -1,4 +1,4 @@
-import { Home, FolderOpen, Files, CheckSquare, User, Search, Bell, Plus, Star, ChevronRight, MapPin } from "lucide-react";
+import { Home, FolderOpen, Files, CheckSquare, User, Search, Bell, Plus, Star, ChevronRight, Zap, MessageSquare, AlertCircle, MapPin, Camera, Palette, BookOpen } from "lucide-react";
 
 export default function MobileShellPreview() {
   return (
@@ -11,105 +11,161 @@ export default function MobileShellPreview() {
         {/* Main Container */}
         <div className="h-full w-full flex flex-col bg-slate-950 relative">
           {/* Proof Header */}
-          <div className="bg-amber-500/10 border-b border-amber-500/30 px-4 py-2 text-center">
+          <div className="bg-amber-500/10 border-b border-amber-500/30 px-4 py-3 text-center">
             <p className="text-xs font-bold text-amber-500 uppercase tracking-wider">Slate360 Mobile Shell Preview</p>
+            <p className="text-xs text-amber-400 mt-1">Home screen proof</p>
           </div>
 
-          {/* Top Bar */}
-          <div className="flex items-center justify-between px-4 py-3 bg-slate-950 border-b border-slate-800">
-            <div className="flex items-center gap-2">
-              <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M12 2L20 6V10L12 14L4 10V6L12 2Z" fill="#D4AF37" opacity="0.8" />
-                <path d="M12 10L20 14V18L12 22L4 18V14L12 10Z" fill="#D4AF37" />
-              </svg>
-              <span className="text-xs font-bold text-slate-300 hidden sm:inline">SLATE360</span>
+          {/* Top Bar - Enhanced Branding */}
+          <div className="flex items-center justify-between px-4 py-3 bg-slate-950 border-b border-amber-500/20">
+            {/* Logo - Stronger Slate360 Branding */}
+            <div className="flex items-center gap-3">
+              <div className="relative w-8 h-8">
+                <svg className="w-full h-full" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <defs>
+                    <linearGradient id="slate360gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                      <stop offset="0%" stopColor="#D4AF37" stopOpacity="1" />
+                      <stop offset="100%" stopColor="#C4A027" stopOpacity="0.8" />
+                    </linearGradient>
+                  </defs>
+                  <path d="M12 2L20 6V10L12 14L4 10V6L12 2Z" fill="url(#slate360gradient)" />
+                  <path d="M12 10L20 14V18L12 22L4 18V14L12 10Z" fill="#D4AF37" />
+                </svg>
+              </div>
+              <span className="text-xs font-bold text-amber-300 tracking-widest hidden sm:inline">SLATE360</span>
             </div>
+
+            {/* Actions */}
             <div className="flex items-center gap-1">
-              <button className="p-2 hover:bg-slate-900 rounded-lg">
-                <Search size={16} className="text-slate-500" />
+              <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors">
+                <Search size={18} className="text-slate-400" />
               </button>
-              <button className="p-2 hover:bg-slate-900 rounded-lg relative">
-                <Bell size={16} className="text-slate-500" />
+              <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors relative">
+                <Bell size={18} className="text-slate-400" />
                 <span className="absolute top-1 right-1 w-1.5 h-1.5 bg-amber-500 rounded-full" />
               </button>
-              <div className="w-7 h-7 bg-slate-800 rounded-full flex items-center justify-center border border-slate-700">
-                <span className="text-xs font-bold text-slate-300">JD</span>
+              <div className="w-8 h-8 bg-slate-800 rounded-full flex items-center justify-center border border-amber-500/50">
+                <span className="text-xs font-bold text-amber-500">JD</span>
               </div>
             </div>
           </div>
 
-          {/* Content */}
-          <div className="flex-1 overflow-y-auto px-3 py-3 pb-20 space-y-3">
-            {/* Apps */}
+          {/* Content - Home Screen Only */}
+          <div className="flex-1 overflow-y-auto px-3 py-4 pb-24 space-y-6">
+            {/* PRIORITY 1: Subscribed Apps - Horizontal Scrollable Launcher */}
             <div>
-              <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider mb-2">Apps</h3>
-              <div className="grid grid-cols-2 gap-2">
-                <button className="aspect-square bg-slate-800 border border-slate-700 hover:border-amber-500/50 rounded-lg flex flex-col items-center justify-center gap-1.5 transition-all">
-                  <MapPin size={16} className="text-slate-400" />
-                  <span className="text-xs font-medium text-slate-300">Site Walk</span>
-                </button>
-                <button className="aspect-square bg-slate-800 border border-slate-700 hover:border-slate-600 rounded-lg flex flex-col items-center justify-center gap-1.5 transition-all">
-                  <Plus size={16} className="text-slate-500" />
-                  <span className="text-xs font-medium text-slate-400">More</span>
-                </button>
+              <h3 className="text-xs font-bold text-amber-300 uppercase tracking-wider mb-3 px-1">Apps</h3>
+              <div className="flex gap-3 overflow-x-auto pb-2 -mx-3 px-3 snap-x snap-mandatory">
+                {[
+                  { label: "Site Walk", icon: MapPin, accent: "from-orange-600 to-orange-700" },
+                  { label: "360 Tours", icon: Camera, accent: "from-cyan-600 to-cyan-700" },
+                  { label: "Design Studio", icon: Palette, accent: "from-purple-600 to-purple-700" },
+                  { label: "Content Studio", icon: BookOpen, accent: "from-emerald-600 to-emerald-700" },
+                ].map((app, idx) => (
+                  <button
+                    key={idx}
+                    className="flex-shrink-0 w-28 aspect-square snap-center"
+                  >
+                    <div className={`h-full w-full bg-gradient-to-br ${app.accent} border border-yellow-600/30 hover:border-amber-500 rounded-xl flex flex-col items-center justify-center gap-2 transition-all hover:shadow-lg hover:shadow-amber-500/30 group`}>
+                      <div className="p-2 bg-white/10 group-hover:bg-white/20 rounded-lg transition-colors">
+                        <app.icon size={18} className="text-white" />
+                      </div>
+                      <span className="text-xs font-semibold text-white text-center px-1 line-clamp-2">{app.label}</span>
+                    </div>
+                  </button>
+                ))}
               </div>
+              <p className="text-xs text-slate-500 mt-2 px-1">Swipe to see more</p>
             </div>
 
-            {/* Notifications */}
+            {/* PRIORITY 2: Communications & Workflow Feed */}
             <div>
-              <div className="flex items-center justify-between mb-2">
-                <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider">Notifications</h3>
-                <span className="text-xs font-semibold text-amber-500">3</span>
+              <div className="flex items-center justify-between mb-3 px-1">
+                <h3 className="text-xs font-bold text-amber-300 uppercase tracking-wider">Notifications</h3>
+                <span className="inline-block px-2 py-0.5 text-xs font-semibold bg-amber-500 text-slate-950 rounded-sm">3</span>
               </div>
-              <div className="space-y-1.5">
+              <div className="space-y-2">
                 {[
-                  "Design review requested",
-                  "Field upload pending",
-                  "Specification update",
+                  { label: "Design review requested", source: "Sarah Chen", type: "review", time: "2h ago" },
+                  { label: "Contractor uploaded files", source: "Field Team", type: "upload", time: "4h ago" },
+                  { label: "Specification update pending", source: "System", type: "submission", time: "1d ago" },
                 ].map((item, idx) => (
-                  <div key={idx} className="flex items-start gap-2 p-2 bg-slate-800/50 border border-slate-700 hover:bg-slate-800 rounded-lg transition-colors cursor-pointer">
-                    <div className="w-2 h-2 bg-amber-500 rounded-full mt-1.5 flex-shrink-0" />
-                    <p className="text-xs font-medium text-slate-300">{item}</p>
+                  <div
+                    key={idx}
+                    className="flex items-start gap-3 p-3 bg-slate-900/60 border border-slate-800 hover:bg-slate-800/80 hover:border-amber-500/40 transition-all cursor-pointer"
+                  >
+                    <div className="pt-1 flex-shrink-0">
+                      {item.type === "review" && <AlertCircle size={14} className="text-amber-500" />}
+                      {item.type === "upload" && <MessageSquare size={14} className="text-cyan-400" />}
+                      {item.type === "submission" && <CheckSquare size={14} className="text-emerald-400" />}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-slate-200">{item.label}</p>
+                      <div className="flex items-center justify-between mt-1">
+                        <p className="text-xs text-slate-500">{item.source}</p>
+                        <p className="text-xs text-slate-600">{item.time}</p>
+                      </div>
+                    </div>
+                    <ChevronRight size={14} className="text-slate-600 flex-shrink-0 mt-1" />
                   </div>
                 ))}
               </div>
             </div>
 
-            {/* Quick Actions */}
+            {/* PRIORITY 3: Quick Actions - Entitlement Aware */}
             <div>
-              <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider mb-2">Quick Actions</h3>
-              <div className="grid grid-cols-2 gap-2">
+              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Quick Actions</h3>
+              <div className="grid grid-cols-2 gap-3">
                 {[
-                  { icon: Plus, label: "New" },
-                  { icon: Files, label: "Files" },
-                  { icon: Star, label: "Pinned" },
-                  { icon: ChevronRight, label: "Browse" },
+                  { icon: Plus, label: "New Project" },
+                  { icon: Zap, label: "Continue Work" },
+                  { icon: Files, label: "Open Files" },
+                  { icon: MessageSquare, label: "Report & Suggest" },
                 ].map((action, idx) => (
-                  <button key={idx} className="p-2 bg-slate-800/50 border border-slate-700 hover:border-slate-600 rounded-lg flex flex-col items-center gap-1 transition-colors">
-                    <action.icon size={14} className="text-slate-400" />
-                    <span className="text-xs font-medium text-slate-400">{action.label}</span>
+                  <button
+                    key={idx}
+                    className="p-3 bg-slate-900/60 border border-slate-800 hover:border-amber-500/50 rounded-lg transition-all flex flex-col items-center gap-2 hover:bg-slate-800/80 hover:shadow-md"
+                  >
+                    <div className="p-2 bg-amber-500/20 rounded-lg">
+                      <action.icon size={16} className="text-amber-300" />
+                    </div>
+                    <span className="text-xs font-medium text-slate-300 text-center">{action.label}</span>
                   </button>
                 ))}
               </div>
             </div>
 
-            {/* Pinned Projects */}
-            <div>
-              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Pinned</h3>
+            {/* PRIORITY 4: Pinned Projects - Lower Prominence */}
+            <div className="pt-2">
+              <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2 px-1">Pinned</h3>
               <div className="space-y-1">
-                {[1, 2].map((idx) => (
-                  <div key={idx} className="flex items-center gap-2 p-2 bg-slate-800/30 border border-slate-800 rounded hover:bg-slate-800/50 transition-colors cursor-pointer">
-                    <Star size={10} className="text-slate-600" fill="currentColor" />
-                    <p className="text-xs text-slate-400">Project</p>
-                    <ChevronRight size={10} className="text-slate-600 ml-auto" />
+                {[1, 2, 3].map((idx) => (
+                  <div key={idx} className="flex items-center gap-2 p-2 bg-slate-900/40 border border-slate-800/50 hover:bg-slate-800/60 transition-colors cursor-pointer rounded">
+                    <Star size={12} className="text-slate-600 flex-shrink-0" fill="currentColor" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xs font-medium text-slate-400">Project</p>
+                    </div>
+                    <ChevronRight size={12} className="text-slate-700" />
                   </div>
                 ))}
               </div>
             </div>
+
+            {/* PRIORITY 5: Quick Search */}
+            <div className="pt-2">
+              <div className="relative">
+                <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-600" />
+                <input
+                  type="text"
+                  placeholder="Search..."
+                  className="w-full pl-10 pr-4 py-2 bg-slate-900/40 border border-slate-800/50 rounded-lg text-xs text-slate-300 placeholder:text-slate-600 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
+                />
+              </div>
+            </div>
           </div>
 
-          {/* Bottom Navigation */}
-          <div className="absolute bottom-0 left-0 right-0 flex justify-around items-center h-16 bg-slate-950/95 border-t border-slate-800 px-2">
+          {/* Bottom Navigation - Static */}
+          <div className="absolute bottom-0 left-0 right-0 flex justify-around items-center h-20 bg-slate-950/95 border-t border-amber-500/10 backdrop-blur-sm px-2">
             {[
               { icon: Home, label: "Home", active: true },
               { icon: FolderOpen, label: "Projects" },
@@ -119,11 +175,11 @@ export default function MobileShellPreview() {
             ].map((nav, idx) => (
               <button
                 key={idx}
-                className={`flex flex-col items-center justify-center gap-0.5 py-1 px-1 rounded text-xs font-medium ${
-                  nav.active ? "text-amber-500" : "text-slate-500 hover:text-slate-400"
+                className={`flex flex-col items-center justify-center gap-1 py-2 px-2 rounded-lg transition-all text-xs font-medium ${
+                  nav.active ? "text-amber-500 bg-amber-500/10" : "text-slate-500 hover:text-slate-400"
                 }`}
               >
-                <nav.icon size={16} />
+                <nav.icon size={18} />
                 <span className="text-xs">{nav.label}</span>
               </button>
             ))}

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -42,10 +42,10 @@ export default function MobileShellPreview() {
               </button>
               <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors relative">
                 <Bell size={18} className="text-slate-400" />
-                <span className="absolute top-1 right-1 w-1.5 h-1.5 bg-amber-500 rounded-full" />
+                <span className="absolute top-1 right-1 w-1.5 h-1.5 bg-amber-400 rounded-full" />
               </button>
-              <div className="w-8 h-8 bg-slate-800 rounded-full flex items-center justify-center border border-amber-500/50">
-                <span className="text-xs font-bold text-amber-500">JD</span>
+              <div className="w-8 h-8 bg-slate-800 rounded-full flex items-center justify-center border border-amber-400/50">
+                <span className="text-xs font-bold text-amber-400">JD</span>
               </div>
             </div>
           </div>
@@ -86,7 +86,7 @@ export default function MobileShellPreview() {
             <div>
               <div className="flex items-center justify-between mb-3 px-1">
                 <h3 className="text-xs font-bold text-amber-300 uppercase tracking-wider">Notifications</h3>
-                <span className="inline-block px-2 py-0.5 text-xs font-semibold bg-amber-500 text-slate-950 rounded-sm">3</span>
+                <span className="inline-block px-2 py-0.5 text-xs font-semibold bg-amber-400 text-slate-950 rounded-sm">3</span>
               </div>
               <div className="space-y-2">
                 {[
@@ -99,9 +99,9 @@ export default function MobileShellPreview() {
                     className="flex items-start gap-3 p-3 bg-slate-900/60 border border-amber-400/30 hover:bg-slate-800/80 hover:border-amber-400 transition-all cursor-pointer"
                   >
                     <div className="pt-1 flex-shrink-0">
-                      {item.type === "review" && <AlertCircle size={14} className="text-amber-500" />}
-                      {item.type === "upload" && <MessageSquare size={14} className="text-cyan-400" />}
-                      {item.type === "submission" && <CheckSquare size={14} className="text-emerald-400" />}
+                      {item.type === "review" && <AlertCircle size={14} className="text-amber-400" />}
+                      {item.type === "upload" && <MessageSquare size={14} className="text-amber-400" />}
+                      {item.type === "submission" && <CheckSquare size={14} className="text-amber-400" />}
                     </div>
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-medium text-slate-200">{item.label}</p>

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -67,7 +67,7 @@ export default function MobileShellPreview() {
                       key={idx}
                       className="relative group"
                     >
-                      <div className="aspect-square bg-slate-800/40 border border-slate-700 hover:border-amber-500/60 rounded-lg flex flex-col items-center justify-center gap-0.5 transition-all hover:bg-slate-800/80 hover:shadow-md hover:shadow-amber-500/20">
+                      <div className="aspect-square bg-slate-800/40 border border-amber-400/30 hover:border-amber-400 rounded-lg flex flex-col items-center justify-center gap-0.5 transition-all hover:bg-slate-800/80 hover:shadow-md hover:shadow-amber-400/20">
                         <div className="p-1.5 bg-slate-700/50 group-hover:bg-slate-700 rounded-md transition-colors">
                           <app.icon size={11} className="text-slate-300 group-hover:text-amber-300" />
                         </div>

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -1,6 +1,27 @@
 import { Home, FolderOpen, Files, CheckSquare, User, Search, Bell, Plus, Star, ChevronRight, Zap, MessageSquare, AlertCircle, MapPin, Camera, Palette, BookOpen } from "lucide-react";
 
 export default function MobileShellPreview() {
+  const apps = [
+    { label: "Site Walk", icon: MapPin, status: "live" },
+    { label: "360 Tours", icon: Camera, status: "coming" },
+    { label: "Design Studio", icon: Palette, status: "coming" },
+    { label: "Content Studio", icon: BookOpen, status: "coming" },
+  ];
+
+  // Calculate grid columns based on app count
+  const getGridCols = () => {
+    if (apps.length === 1) return "grid-cols-1";
+    if (apps.length === 3) return "grid-cols-2";
+    return "grid-cols-2";
+  };
+
+  // Calculate max-width based on app count
+  const getMaxWidth = () => {
+    if (apps.length === 1) return "max-w-[110px]";
+    if (apps.length === 3) return "max-w-[202px]";
+    return "max-w-[202px]";
+  };
+
   return (
     <div className="min-h-screen bg-slate-950 dark flex items-center justify-center p-4">
       {/* Mobile Phone Frame */}
@@ -11,28 +32,28 @@ export default function MobileShellPreview() {
         {/* Main Container */}
         <div className="h-full w-full flex flex-col bg-slate-950 relative">
           {/* Proof Header */}
-          <div className="bg-amber-500/10 border-b border-amber-500/30 px-4 py-3 text-center">
-            <p className="text-xs font-bold text-amber-500 uppercase tracking-wider">Slate360 Mobile Shell Preview</p>
-            <p className="text-xs text-amber-400 mt-1">Home screen proof</p>
+          <div className="bg-yellow-500/10 border-b border-yellow-500/30 px-4 py-3 text-center">
+            <p className="text-xs font-bold text-yellow-500 uppercase tracking-wider">Slate360 Mobile Shell Preview</p>
+            <p className="text-xs text-yellow-400 mt-1">Home screen proof</p>
           </div>
 
           {/* Top Bar - Enhanced Branding */}
-          <div className="flex items-center justify-between px-4 py-3 bg-slate-950 border-b border-amber-500/20">
-            {/* Logo - Stronger Slate360 Branding */}
+          <div className="flex items-center justify-between px-4 py-3 bg-slate-950 border-b border-yellow-500/20">
+            {/* Logo */}
             <div className="flex items-center gap-3">
               <div className="relative w-8 h-8">
                 <svg className="w-full h-full" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <defs>
                     <linearGradient id="slate360gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                      <stop offset="0%" stopColor="#D4AF37" stopOpacity="1" />
-                      <stop offset="100%" stopColor="#C4A027" stopOpacity="0.8" />
+                      <stop offset="0%" stopColor="#FBBF24" stopOpacity="1" />
+                      <stop offset="100%" stopColor="#F59E0B" stopOpacity="0.8" />
                     </linearGradient>
                   </defs>
                   <path d="M12 2L20 6V10L12 14L4 10V6L12 2Z" fill="url(#slate360gradient)" />
-                  <path d="M12 10L20 14V18L12 22L4 18V14L12 10Z" fill="#D4AF37" />
+                  <path d="M12 10L20 14V18L12 22L4 18V14L12 10Z" fill="#FBBF24" />
                 </svg>
               </div>
-              <span className="text-xs font-bold text-amber-300 tracking-widest hidden sm:inline">SLATE360</span>
+              <span className="text-xs font-bold text-yellow-300 tracking-widest hidden sm:inline">SLATE360</span>
             </div>
 
             {/* Actions */}
@@ -42,10 +63,10 @@ export default function MobileShellPreview() {
               </button>
               <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors relative">
                 <Bell size={18} className="text-slate-400" />
-                <span className="absolute top-1 right-1 w-1.5 h-1.5 bg-amber-400 rounded-full" />
+                <span className="absolute top-1 right-1 w-1.5 h-1.5 bg-yellow-400 rounded-full" />
               </button>
-              <div className="w-8 h-8 bg-slate-800 rounded-full flex items-center justify-center border border-amber-400/50">
-                <span className="text-xs font-bold text-amber-400">JD</span>
+              <div className="w-8 h-8 bg-slate-800 rounded-full flex items-center justify-center border border-yellow-400/50">
+                <span className="text-xs font-bold text-yellow-400">JD</span>
               </div>
             </div>
           </div>
@@ -54,26 +75,21 @@ export default function MobileShellPreview() {
           <div className="flex-1 overflow-y-auto px-3 py-4 pb-24 space-y-6">
             {/* PRIORITY 1: Subscribed Apps - Premium Adaptive Grid */}
             <div>
-              <h3 className="text-xs font-bold text-amber-300 uppercase tracking-wider mb-2 px-1">Apps</h3>
+              <h3 className="text-xs font-bold text-yellow-300 uppercase tracking-wider mb-2 px-1">Apps</h3>
               <div className="flex justify-center w-full">
-                <div className="grid gap-x-3 gap-y-3 w-full max-w-[202px]" style={{ gridTemplateColumns: "repeat(2, 1fr)" }}>
-                  {[
-                    { label: "Site Walk", icon: MapPin, status: "live" },
-                    { label: "360 Tours", icon: Camera, status: "coming" },
-                    { label: "Design Studio", icon: Palette, status: "coming" },
-                    { label: "Content Studio", icon: BookOpen, status: "coming" },
-                  ].map((app, idx) => (
+                <div className={`grid gap-x-3 gap-y-2 w-full ${getGridCols()} ${getMaxWidth()}`}>
+                  {apps.map((app, idx) => (
                     <button
                       key={idx}
                       className="relative group"
                     >
-                      <div className="aspect-square bg-slate-800/40 border border-amber-400/30 hover:border-amber-400 rounded-lg flex flex-col items-center justify-center gap-0.5 transition-all hover:bg-slate-800/80 hover:shadow-md hover:shadow-amber-400/20">
-                        <div className="p-1.5 bg-slate-700/50 group-hover:bg-slate-700 rounded-md transition-colors">
-                          <app.icon size={11} className="text-slate-300 group-hover:text-amber-300" />
+                      <div className="h-20 bg-slate-800/50 border border-yellow-500/40 hover:border-yellow-400 rounded-xl flex flex-col items-center justify-center gap-0.5 transition-all hover:bg-slate-800 hover:shadow-md hover:shadow-yellow-400/15">
+                        <div className="p-1.5 bg-slate-700/50 group-hover:bg-slate-600 rounded-lg transition-colors">
+                          <app.icon size={14} className="text-slate-300 group-hover:text-yellow-300" />
                         </div>
                         <span className="text-xs font-medium text-slate-100 text-center px-0.5 leading-tight">{app.label}</span>
                         {app.status === "coming" && (
-                          <span className="text-xs font-medium text-slate-500 opacity-75 text-center leading-none">Coming<br />Soon</span>
+                          <span className="text-xs font-medium text-slate-500 opacity-70 text-center leading-none">Coming<br />Soon</span>
                         )}
                       </div>
                     </button>
@@ -84,9 +100,9 @@ export default function MobileShellPreview() {
 
             {/* PRIORITY 2: Communications & Workflow Feed */}
             <div>
-              <div className="flex items-center justify-between mb-3 px-1">
-                <h3 className="text-xs font-bold text-amber-300 uppercase tracking-wider">Notifications</h3>
-                <span className="inline-block px-2 py-0.5 text-xs font-semibold bg-amber-400 text-slate-950 rounded-sm">3</span>
+              <div className="flex items-center justify-between mb-2 px-1">
+                <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider">Notifications</h3>
+                <span className="inline-block px-2 py-0.5 text-xs font-semibold bg-yellow-500/90 text-slate-950 rounded-sm">3</span>
               </div>
               <div className="space-y-2">
                 {[
@@ -96,12 +112,12 @@ export default function MobileShellPreview() {
                 ].map((item, idx) => (
                   <div
                     key={idx}
-                    className="flex items-start gap-3 p-3 bg-slate-900/60 border border-amber-400/30 hover:bg-slate-800/80 hover:border-amber-400 transition-all cursor-pointer"
+                    className="flex items-start gap-3 p-3 bg-slate-800/50 border border-slate-700 hover:border-blue-500/40 rounded-lg transition-all cursor-pointer hover:bg-slate-800"
                   >
                     <div className="pt-1 flex-shrink-0">
-                      {item.type === "review" && <AlertCircle size={14} className="text-amber-400" />}
-                      {item.type === "upload" && <MessageSquare size={14} className="text-amber-400" />}
-                      {item.type === "submission" && <CheckSquare size={14} className="text-amber-400" />}
+                      {item.type === "review" && <AlertCircle size={14} className="text-yellow-400" />}
+                      {item.type === "upload" && <MessageSquare size={14} className="text-yellow-400" />}
+                      {item.type === "submission" && <CheckSquare size={14} className="text-yellow-400" />}
                     </div>
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-medium text-slate-200">{item.label}</p>
@@ -116,9 +132,9 @@ export default function MobileShellPreview() {
               </div>
             </div>
 
-            {/* PRIORITY 3: Quick Actions - Entitlement Aware */}
+            {/* PRIORITY 3: Quick Actions - Same Design Family */}
             <div>
-              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Quick Actions</h3>
+              <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider mb-2 px-1">Quick Actions</h3>
               <div className="grid grid-cols-2 gap-3">
                 {[
                   { icon: Plus, label: "New Project" },
@@ -128,12 +144,12 @@ export default function MobileShellPreview() {
                 ].map((action, idx) => (
                   <button
                     key={idx}
-                    className="p-3 bg-slate-900/60 border border-amber-400/30 hover:border-amber-400 rounded-lg transition-all flex flex-col items-center gap-2 hover:bg-slate-800/80 hover:shadow-md"
+                    className="h-20 bg-slate-800/50 border border-slate-700 hover:border-blue-500/40 rounded-xl transition-all flex flex-col items-center justify-center gap-1 hover:bg-slate-800"
                   >
-                    <div className="p-2 bg-amber-500/20 rounded-lg">
-                      <action.icon size={16} className="text-amber-300" />
+                    <div className="p-1.5 bg-slate-700/50 rounded-lg">
+                      <action.icon size={14} className="text-yellow-400" />
                     </div>
-                    <span className="text-xs font-medium text-slate-300 text-center">{action.label}</span>
+                    <span className="text-xs font-medium text-slate-300 text-center px-0.5">{action.label}</span>
                   </button>
                 ))}
               </div>
@@ -144,7 +160,7 @@ export default function MobileShellPreview() {
               <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2 px-1">Pinned</h3>
               <div className="space-y-1">
                 {[1, 2, 3].map((idx) => (
-                  <div key={idx} className="flex items-center gap-2 p-2 bg-slate-900/40 border border-amber-400/30 hover:border-amber-400 hover:bg-slate-800/60 transition-colors cursor-pointer rounded">
+                  <div key={idx} className="flex items-center gap-2 p-2 bg-slate-800/40 border border-slate-700 hover:border-blue-500/40 rounded transition-colors cursor-pointer">
                     <Star size={12} className="text-slate-600 flex-shrink-0" fill="currentColor" />
                     <div className="flex-1 min-w-0">
                       <p className="text-xs font-medium text-slate-400">Project</p>
@@ -162,14 +178,14 @@ export default function MobileShellPreview() {
                 <input
                   type="text"
                   placeholder="Search..."
-                  className="w-full pl-10 pr-4 py-2 bg-slate-900/40 border border-slate-800/50 rounded-lg text-xs text-slate-300 placeholder:text-slate-600 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
+                  className="w-full pl-10 pr-4 py-2 bg-slate-800/40 border border-slate-700 rounded-lg text-xs text-slate-300 placeholder:text-slate-600 focus:outline-none focus:ring-2 focus:ring-yellow-500/50 focus:border-transparent"
                 />
               </div>
             </div>
           </div>
 
           {/* Bottom Navigation - Static */}
-          <div className="absolute bottom-0 left-0 right-0 flex justify-around items-center h-20 bg-slate-950/95 border-t border-amber-500/10 backdrop-blur-sm px-2">
+          <div className="absolute bottom-0 left-0 right-0 flex justify-around items-center h-20 bg-slate-950/95 border-t border-slate-800 backdrop-blur-sm px-2">
             {[
               { icon: Home, label: "Home", active: true },
               { icon: FolderOpen, label: "Projects" },
@@ -180,7 +196,7 @@ export default function MobileShellPreview() {
               <button
                 key={idx}
                 className={`flex flex-col items-center justify-center gap-1 py-2 px-2 rounded-lg transition-all text-xs font-medium ${
-                  nav.active ? "text-amber-500 bg-amber-500/10" : "text-slate-500 hover:text-slate-400"
+                  nav.active ? "text-blue-400 bg-blue-500/10" : "text-slate-500 hover:text-slate-400"
                 }`}
               >
                 <nav.icon size={18} />

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -96,7 +96,7 @@ export default function MobileShellPreview() {
                 ].map((item, idx) => (
                   <div
                     key={idx}
-                    className="flex items-start gap-3 p-3 bg-slate-900/60 border border-slate-800 hover:bg-slate-800/80 hover:border-amber-500/40 transition-all cursor-pointer"
+                    className="flex items-start gap-3 p-3 bg-slate-900/60 border border-amber-400/30 hover:bg-slate-800/80 hover:border-amber-400 transition-all cursor-pointer"
                   >
                     <div className="pt-1 flex-shrink-0">
                       {item.type === "review" && <AlertCircle size={14} className="text-amber-500" />}
@@ -128,7 +128,7 @@ export default function MobileShellPreview() {
                 ].map((action, idx) => (
                   <button
                     key={idx}
-                    className="p-3 bg-slate-900/60 border border-slate-800 hover:border-amber-500/50 rounded-lg transition-all flex flex-col items-center gap-2 hover:bg-slate-800/80 hover:shadow-md"
+                    className="p-3 bg-slate-900/60 border border-amber-400/30 hover:border-amber-400 rounded-lg transition-all flex flex-col items-center gap-2 hover:bg-slate-800/80 hover:shadow-md"
                   >
                     <div className="p-2 bg-amber-500/20 rounded-lg">
                       <action.icon size={16} className="text-amber-300" />
@@ -144,7 +144,7 @@ export default function MobileShellPreview() {
               <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2 px-1">Pinned</h3>
               <div className="space-y-1">
                 {[1, 2, 3].map((idx) => (
-                  <div key={idx} className="flex items-center gap-2 p-2 bg-slate-900/40 border border-slate-800/50 hover:bg-slate-800/60 transition-colors cursor-pointer rounded">
+                  <div key={idx} className="flex items-center gap-2 p-2 bg-slate-900/40 border border-amber-400/30 hover:border-amber-400 hover:bg-slate-800/60 transition-colors cursor-pointer rounded">
                     <Star size={12} className="text-slate-600 flex-shrink-0" fill="currentColor" />
                     <div className="flex-1 min-w-0">
                       <p className="text-xs font-medium text-slate-400">Project</p>

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -52,32 +52,34 @@ export default function MobileShellPreview() {
 
           {/* Content - Home Screen Only */}
           <div className="flex-1 overflow-y-auto px-3 py-4 pb-24 space-y-6">
-            {/* PRIORITY 1: Subscribed Apps - Premium Grid Layout */}
+            {/* PRIORITY 1: Subscribed Apps - Premium Adaptive Grid */}
             <div>
-              <h3 className="text-xs font-bold text-amber-300 uppercase tracking-wider mb-3 px-1">Apps</h3>
+              <h3 className="text-xs font-bold text-amber-300 uppercase tracking-wider mb-2 px-1">Apps</h3>
               <div className="flex justify-center">
-                <div className="w-full grid gap-2" style={{ gridTemplateColumns: "repeat(2, minmax(0, 1fr))", maxWidth: "280px" }}>
+                <div className="grid gap-2.5 w-full max-w-xs" style={{ gridTemplateColumns: "repeat(2, 1fr)" }}>
                   {[
-                    { label: "Site Walk", icon: MapPin },
-                    { label: "360 Tours", icon: Camera },
-                    { label: "Design Studio", icon: Palette },
-                    { label: "Content Studio", icon: BookOpen },
+                    { label: "Site Walk", icon: MapPin, status: "live" },
+                    { label: "360 Tours", icon: Camera, status: "coming" },
+                    { label: "Design Studio", icon: Palette, status: "coming" },
+                    { label: "Content Studio", icon: BookOpen, status: "coming" },
                   ].map((app, idx) => (
                     <button
                       key={idx}
-                      className="aspect-square bg-slate-800/50 border border-slate-700 hover:border-amber-500/40 rounded-lg flex flex-col items-center justify-center gap-1.5 transition-all hover:bg-slate-800 hover:shadow-lg hover:shadow-amber-500/20 group"
+                      className="relative group"
                     >
-                      <div className="p-2 bg-slate-700/60 group-hover:bg-slate-700 rounded-lg transition-colors">
-                        <app.icon size={18} className="text-slate-300 group-hover:text-amber-400" />
+                      <div className="aspect-square bg-slate-800/40 border border-slate-700 hover:border-amber-500/60 rounded-lg flex flex-col items-center justify-center gap-1 transition-all hover:bg-slate-800/80 hover:shadow-md hover:shadow-amber-500/20">
+                        <div className="p-2 bg-slate-700/50 group-hover:bg-slate-700 rounded-lg transition-colors">
+                          <app.icon size={16} className="text-slate-300 group-hover:text-amber-300" />
+                        </div>
+                        <span className="text-xs font-medium text-slate-100 text-center px-0.5">{app.label}</span>
+                        {app.status === "coming" && (
+                          <span className="text-xs font-medium text-slate-500 opacity-75 text-center leading-none">Coming</span>
+                        )}
                       </div>
-                      <span className="text-xs font-medium text-slate-200 text-center px-1 line-clamp-1">{app.label}</span>
                     </button>
                   ))}
                 </div>
               </div>
-              <button className="w-full mt-2 py-1.5 text-xs font-medium text-slate-500 hover:text-slate-400 transition-colors border border-dashed border-slate-700 hover:border-slate-600 rounded">
-                More apps
-              </button>
             </div>
 
             {/* PRIORITY 2: Communications & Workflow Feed */}

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -52,30 +52,32 @@ export default function MobileShellPreview() {
 
           {/* Content - Home Screen Only */}
           <div className="flex-1 overflow-y-auto px-3 py-4 pb-24 space-y-6">
-            {/* PRIORITY 1: Subscribed Apps - Horizontal Scrollable Launcher */}
+            {/* PRIORITY 1: Subscribed Apps - Premium Grid Layout */}
             <div>
               <h3 className="text-xs font-bold text-amber-300 uppercase tracking-wider mb-3 px-1">Apps</h3>
-              <div className="flex gap-3 overflow-x-auto pb-2 -mx-3 px-3 snap-x snap-mandatory">
-                {[
-                  { label: "Site Walk", icon: MapPin, accent: "from-orange-600 to-orange-700" },
-                  { label: "360 Tours", icon: Camera, accent: "from-cyan-600 to-cyan-700" },
-                  { label: "Design Studio", icon: Palette, accent: "from-purple-600 to-purple-700" },
-                  { label: "Content Studio", icon: BookOpen, accent: "from-emerald-600 to-emerald-700" },
-                ].map((app, idx) => (
-                  <button
-                    key={idx}
-                    className="flex-shrink-0 w-28 aspect-square snap-center"
-                  >
-                    <div className={`h-full w-full bg-gradient-to-br ${app.accent} border border-yellow-600/30 hover:border-amber-500 rounded-xl flex flex-col items-center justify-center gap-2 transition-all hover:shadow-lg hover:shadow-amber-500/30 group`}>
-                      <div className="p-2 bg-white/10 group-hover:bg-white/20 rounded-lg transition-colors">
-                        <app.icon size={18} className="text-white" />
+              <div className="flex justify-center">
+                <div className="w-full grid gap-2" style={{ gridTemplateColumns: "repeat(2, minmax(0, 1fr))", maxWidth: "280px" }}>
+                  {[
+                    { label: "Site Walk", icon: MapPin },
+                    { label: "360 Tours", icon: Camera },
+                    { label: "Design Studio", icon: Palette },
+                    { label: "Content Studio", icon: BookOpen },
+                  ].map((app, idx) => (
+                    <button
+                      key={idx}
+                      className="aspect-square bg-slate-800/50 border border-slate-700 hover:border-amber-500/40 rounded-lg flex flex-col items-center justify-center gap-1.5 transition-all hover:bg-slate-800 hover:shadow-lg hover:shadow-amber-500/20 group"
+                    >
+                      <div className="p-2 bg-slate-700/60 group-hover:bg-slate-700 rounded-lg transition-colors">
+                        <app.icon size={18} className="text-slate-300 group-hover:text-amber-400" />
                       </div>
-                      <span className="text-xs font-semibold text-white text-center px-1 line-clamp-2">{app.label}</span>
-                    </div>
-                  </button>
-                ))}
+                      <span className="text-xs font-medium text-slate-200 text-center px-1 line-clamp-1">{app.label}</span>
+                    </button>
+                  ))}
+                </div>
               </div>
-              <p className="text-xs text-slate-500 mt-2 px-1">Swipe to see more</p>
+              <button className="w-full mt-2 py-1.5 text-xs font-medium text-slate-500 hover:text-slate-400 transition-colors border border-dashed border-slate-700 hover:border-slate-600 rounded">
+                More apps
+              </button>
             </div>
 
             {/* PRIORITY 2: Communications & Workflow Feed */}

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -8,19 +8,17 @@ export default function MobileShellPreview() {
     { label: "Content Studio", icon: BookOpen, status: "coming" },
   ];
 
-  // Calculate grid columns based on app count
-  const getGridCols = () => {
-    if (apps.length === 1) return "grid-cols-1";
-    if (apps.length === 3) return "grid-cols-2";
-    return "grid-cols-2";
+  // Calculate grid layout based on app count
+  const getAppGridLayout = () => {
+    const count = apps.length;
+    if (count === 1) return { cols: "grid-cols-1", maxW: "max-w-[140px]" };
+    if (count === 2) return { cols: "grid-cols-2", maxW: "max-w-[240px]" };
+    if (count === 3) return { cols: "grid-cols-2", maxW: "max-w-[240px]" };
+    // 4+ returns 2x2 grid
+    return { cols: "grid-cols-2", maxW: "max-w-[240px]" };
   };
 
-  // Calculate max-width based on app count
-  const getMaxWidth = () => {
-    if (apps.length === 1) return "max-w-[110px]";
-    if (apps.length === 3) return "max-w-[202px]";
-    return "max-w-[202px]";
-  };
+  const gridLayout = getAppGridLayout();
 
   return (
     <div className="min-h-screen bg-slate-950 dark flex items-center justify-center p-4">
@@ -77,7 +75,7 @@ export default function MobileShellPreview() {
             <div>
               <h3 className="text-xs font-bold text-yellow-300 uppercase tracking-wider mb-2 px-1">Apps</h3>
               <div className="flex justify-center w-full">
-                <div className={`grid gap-x-3 gap-y-2 w-full ${getGridCols()} ${getMaxWidth()}`}>
+                <div className={`grid gap-x-3 gap-y-2 w-full ${gridLayout.cols} ${gridLayout.maxW}`}>
                   {apps.map((app, idx) => (
                     <button
                       key={idx}
@@ -112,7 +110,7 @@ export default function MobileShellPreview() {
                 ].map((item, idx) => (
                   <div
                     key={idx}
-                    className="flex items-start gap-3 p-3 bg-slate-800/50 border border-slate-700 hover:border-blue-500/40 rounded-lg transition-all cursor-pointer hover:bg-slate-800"
+                    className="flex items-start gap-3 p-3 bg-slate-800/50 border border-slate-700 hover:border-cyan-700/60 rounded-lg transition-all cursor-pointer hover:bg-slate-800"
                   >
                     <div className="pt-1 flex-shrink-0">
                       {item.type === "review" && <AlertCircle size={14} className="text-yellow-400" />}
@@ -144,7 +142,7 @@ export default function MobileShellPreview() {
                 ].map((action, idx) => (
                   <button
                     key={idx}
-                    className="h-20 bg-slate-800/50 border border-slate-700 hover:border-blue-500/40 rounded-xl transition-all flex flex-col items-center justify-center gap-1 hover:bg-slate-800"
+                    className="h-20 bg-slate-800/50 border border-slate-700 hover:border-cyan-700/60 rounded-xl transition-all flex flex-col items-center justify-center gap-1 hover:bg-slate-800"
                   >
                     <div className="p-1.5 bg-slate-700/50 rounded-lg">
                       <action.icon size={14} className="text-yellow-400" />
@@ -160,7 +158,7 @@ export default function MobileShellPreview() {
               <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2 px-1">Pinned</h3>
               <div className="space-y-1">
                 {[1, 2, 3].map((idx) => (
-                  <div key={idx} className="flex items-center gap-2 p-2 bg-slate-800/40 border border-slate-700 hover:border-blue-500/40 rounded transition-colors cursor-pointer">
+                  <div key={idx} className="flex items-center gap-2 p-2 bg-slate-800/40 border border-slate-700 hover:border-cyan-700/60 rounded transition-colors cursor-pointer">
                     <Star size={12} className="text-slate-600 flex-shrink-0" fill="currentColor" />
                     <div className="flex-1 min-w-0">
                       <p className="text-xs font-medium text-slate-400">Project</p>
@@ -196,7 +194,7 @@ export default function MobileShellPreview() {
               <button
                 key={idx}
                 className={`flex flex-col items-center justify-center gap-1 py-2 px-2 rounded-lg transition-all text-xs font-medium ${
-                  nav.active ? "text-blue-400 bg-blue-500/10" : "text-slate-500 hover:text-slate-400"
+                  nav.active ? "text-cyan-300 bg-cyan-950/40" : "text-slate-500 hover:text-slate-400"
                 }`}
               >
                 <nav.icon size={18} />

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -1,373 +1,155 @@
-"use client";
-
-import { useState } from "react";
-import {
-  Home,
-  FolderOpen,
-  Files,
-  CheckSquare,
-  User,
-  Search,
-  Bell,
-  Plus,
-  Clock,
-  MapPin,
-  MessageSquare,
-  Settings,
-  HelpCircle,
-  Download,
-  BarChart3,
-  ChevronRight,
-  Star,
-  Folder,
-  Archive,
-  Share2,
-  MoreVertical,
-} from "lucide-react";
-
-type Tab = "home" | "projects" | "files" | "tasks" | "account";
+import { Home, FolderOpen, Files, CheckSquare, User, Search, Bell, Plus, Star, ChevronRight } from "lucide-react";
 
 export default function MobileShellPreview() {
-  const [activeTab, setActiveTab] = useState<Tab>("home");
-  const [searchQuery, setSearchQuery] = useState("");
-  const [filesContext, setFilesContext] = useState<"root" | "project">("root");
-
   return (
-    <div className="min-h-screen bg-slate-950 dark overflow-hidden">
-      {/* Mobile Phone Frame Wrapper */}
-      <div className="flex items-center justify-center min-h-screen p-4 dark">
-        <div className="relative w-full max-w-sm bg-slate-950 rounded-3xl shadow-2xl overflow-hidden border-8 border-slate-900" style={{ aspectRatio: "9/19.5" }}>
-          {/* Phone Notch */}
-          <div className="absolute top-0 left-1/2 -translate-x-1/2 w-40 h-7 bg-slate-950 rounded-b-3xl z-50 border-b-2 border-slate-800" />
+    <div className="min-h-screen bg-slate-950 dark flex items-center justify-center p-4">
+      {/* Mobile Phone Frame */}
+      <div className="relative w-full max-w-sm bg-slate-950 rounded-3xl shadow-2xl overflow-hidden border-8 border-slate-900" style={{ aspectRatio: "9/19.5" }}>
+        {/* Notch */}
+        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-40 h-7 bg-slate-950 rounded-b-3xl z-50 border-b-2 border-slate-800" />
 
-          {/* Safe Area Container */}
-          <div className="h-full w-full flex flex-col bg-slate-950 relative">
-            {/* ─────── TOP BAR ─────── */}
-            <div className="flex items-center justify-between px-4 pt-8 pb-4 bg-slate-950 border-b border-slate-900/50 backdrop-blur-sm">
-              {/* Slate360 Logo Mark */}
-              <div className="flex items-center gap-2">
-                <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M12 2L20 6V10L12 14L4 10V6L12 2Z" fill="#D4AF37" opacity="0.8" />
-                  <path d="M12 10L20 14V18L12 22L4 18V14L12 10Z" fill="#D4AF37" />
-                </svg>
-                <span className="text-xs font-bold text-slate-300 hidden xs:inline tracking-widest">SLATE360</span>
+        {/* Main Container */}
+        <div className="h-full w-full flex flex-col bg-slate-950 relative">
+          {/* Proof Header */}
+          <div className="bg-amber-500/10 border-b border-amber-500/30 px-4 py-3 text-center">
+            <p className="text-xs font-bold text-amber-500 uppercase tracking-wider">Slate360 Mobile Shell Preview</p>
+            <p className="text-xs text-amber-400 mt-1">Home screen proof</p>
+          </div>
+
+          {/* Top Bar */}
+          <div className="flex items-center justify-between px-4 py-3 bg-slate-950 border-b border-slate-900/50">
+            {/* Logo */}
+            <div className="flex items-center gap-2">
+              <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 2L20 6V10L12 14L4 10V6L12 2Z" fill="#D4AF37" opacity="0.8" />
+                <path d="M12 10L20 14V18L12 22L4 18V14L12 10Z" fill="#D4AF37" />
+              </svg>
+              <span className="text-xs font-bold text-slate-300 tracking-widest hidden sm:inline">SLATE360</span>
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center gap-2">
+              <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors">
+                <Search size={18} className="text-slate-400" />
+              </button>
+              <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors relative">
+                <Bell size={18} className="text-slate-400" />
+                <span className="absolute top-1 right-1 w-1.5 h-1.5 bg-amber-500 rounded-full" />
+              </button>
+              <div className="w-8 h-8 bg-slate-800 rounded-full flex items-center justify-center border border-slate-700">
+                <span className="text-xs font-bold text-amber-500">JD</span>
               </div>
+            </div>
+          </div>
 
-              {/* Search & Actions */}
-              <div className="flex items-center gap-1">
-                <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors">
-                  <Search size={18} className="text-slate-400" />
-                </button>
-                <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors relative">
-                  <Bell size={18} className="text-slate-400" />
-                  <span className="absolute top-1 right-1 w-1.5 h-1.5 bg-amber-500 rounded-full" />
-                </button>
-                <div className="w-8 h-8 bg-gradient-to-br from-slate-800 to-slate-900 rounded-full flex items-center justify-center border border-slate-700">
-                  <span className="text-xs font-bold text-amber-500">JD</span>
-                </div>
+          {/* Content - Home Screen Only */}
+          <div className="flex-1 overflow-y-auto px-3 py-4 pb-24 space-y-4">
+            {/* Search */}
+            <div className="relative">
+              <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" />
+              <input
+                type="text"
+                placeholder="Find projects..."
+                className="w-full pl-10 pr-4 py-2.5 bg-slate-900/80 border border-slate-800 rounded-xl text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50"
+              />
+            </div>
+
+            {/* Pinned Projects */}
+            <div>
+              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Pinned</h3>
+              <div className="space-y-2">
+                {[1, 2].map((idx) => (
+                  <div key={idx} className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer">
+                    <div className="flex items-center gap-3">
+                      <Star size={14} className="text-amber-500 flex-shrink-0" fill="currentColor" />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-slate-200">Project</p>
+                        <p className="text-xs text-slate-500">Multiple files</p>
+                      </div>
+                      <ChevronRight size={14} className="text-slate-600" />
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
 
-            {/* ─────── CONTENT AREA ─────── */}
-            <div className="flex-1 overflow-y-auto px-3 py-5 pb-24 scroll-smooth space-y-5">
-              {/* HOME TAB */}
-              {activeTab === "home" && (
-                <div className="space-y-5">
-                  {/* Search */}
-                  <div className="relative">
-                    <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" />
-                    <input
-                      type="text"
-                      placeholder="Find projects..."
-                      value={searchQuery}
-                      onChange={(e) => setSearchQuery(e.target.value)}
-                      className="w-full pl-10 pr-4 py-2.5 bg-slate-900/80 border border-slate-800 rounded-xl text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent transition-all"
-                    />
-                  </div>
-
-                  {/* Recent & Quick Access */}
-                  <div>
-                    <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Quick Access</h3>
-                    <div className="grid grid-cols-2 gap-3">
-                      {[
-                        { icon: Plus, label: "New Project" },
-                        { icon: FolderOpen, label: "Open" },
-                        { icon: Files, label: "Files" },
-                        { icon: Clock, label: "Recent" },
-                      ].map((action, idx) => (
-                        <button
-                          key={idx}
-                          className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 hover:border-slate-700 transition-all group"
-                        >
-                          <div className="flex flex-col items-center gap-2">
-                            <div className="p-2 bg-amber-500/20 rounded-lg group-hover:bg-amber-500/30 transition-colors">
-                              <action.icon size={16} className="text-amber-500" />
-                            </div>
-                            <span className="text-xs font-medium text-slate-300">{action.label}</span>
-                          </div>
-                        </button>
-                      ))}
+            {/* Quick Actions */}
+            <div>
+              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Quick Access</h3>
+              <div className="grid grid-cols-2 gap-3">
+                {[
+                  { icon: Plus, label: "New Project" },
+                  { icon: FolderOpen, label: "Open" },
+                  { icon: Files, label: "Files" },
+                  { icon: Home, label: "Recent" },
+                ].map((action, idx) => (
+                  <button
+                    key={idx}
+                    className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-all flex flex-col items-center gap-2"
+                  >
+                    <div className="p-2 bg-amber-500/20 rounded-lg">
+                      <action.icon size={16} className="text-amber-500" />
                     </div>
-                  </div>
-
-                  {/* Pinned Projects */}
-                  <div>
-                    <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Pinned</h3>
-                    <div className="space-y-2">
-                      {[1, 2].map((idx) => (
-                        <div key={idx} className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer group">
-                          <div className="flex items-start gap-3">
-                            <Star size={14} className="text-amber-500 mt-0.5 flex-shrink-0" fill="currentColor" />
-                            <div className="flex-1 min-w-0">
-                              <p className="text-sm font-medium text-slate-200">Project item</p>
-                              <p className="text-xs text-slate-500 mt-0.5">Project · Multiple files</p>
-                            </div>
-                            <ChevronRight size={14} className="text-slate-600" />
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-
-                  {/* Available Modules */}
-                  <div>
-                    <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Explore</h3>
-                    <div className="space-y-2">
-                      {[
-                        { label: "360 Tours" },
-                        { label: "Design Studio" },
-                        { label: "Content Studio" },
-                      ].map((item, idx) => (
-                        <div key={idx} className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer">
-                          <div className="flex items-center justify-between">
-                            <div className="flex items-center gap-3">
-                              <div className="w-2 h-2 bg-amber-500 rounded-full" />
-                              <span className="text-sm font-medium text-slate-300">{item.label}</span>
-                            </div>
-                            <ChevronRight size={14} className="text-slate-600" />
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              {/* PROJECTS TAB */}
-              {activeTab === "projects" && (
-                <div className="space-y-5">
-                  <div className="relative">
-                    <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" />
-                    <input
-                      type="text"
-                      placeholder="Find projects..."
-                      className="w-full pl-10 pr-4 py-2.5 bg-slate-900/80 border border-slate-800 rounded-xl text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent transition-all"
-                    />
-                  </div>
-
-                  <div className="space-y-5">
-                    <div>
-                      <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Pinned</h3>
-                      <div className="grid grid-cols-3 gap-2">
-                        {[1, 2].map((idx) => (
-                          <div key={idx} className="aspect-square bg-slate-900/60 border border-slate-800 rounded-lg flex items-center justify-center hover:bg-slate-800/80 transition-colors cursor-pointer">
-                            <Star size={16} className="text-amber-500" />
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-
-                    {["My Projects", "Team Projects", "Shared", "All Accessible"].map((section, idx) => (
-                      <div key={idx}>
-                        <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">{section}</h3>
-                        <div className="space-y-2">
-                          {[1, 2].map((item) => (
-                            <div key={item} className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer group">
-                              <div className="flex items-center justify-between">
-                                <div className="flex items-center gap-3 flex-1 min-w-0">
-                                  <div className="w-8 h-8 bg-amber-500/15 rounded flex items-center justify-center flex-shrink-0">
-                                    <FolderOpen size={14} className="text-amber-500" />
-                                  </div>
-                                  <div className="min-w-0">
-                                    <p className="text-sm font-medium text-slate-200 truncate">Project</p>
-                                    <p className="text-xs text-slate-500">Multiple files</p>
-                                  </div>
-                                </div>
-                                <ChevronRight size={14} className="text-slate-600" />
-                              </div>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    ))}
-
-                    <button className="w-full flex items-center justify-center gap-2 py-3 bg-amber-500 hover:bg-amber-600 rounded-lg text-sm font-semibold text-slate-950 transition-colors">
-                      <Plus size={16} />
-                      Create New
-                    </button>
-                  </div>
-                </div>
-              )}
-
-              {/* FILES TAB */}
-              {activeTab === "files" && (
-                <div className="space-y-3">
-                  {filesContext === "root" && (
-                    <>
-                      <button
-                        onClick={() => setFilesContext("project")}
-                        className="w-full flex items-center gap-3 p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors"
-                      >
-                        <Folder size={16} className="text-amber-500" />
-                        <span className="text-sm font-medium text-slate-300">Folders</span>
-                        <ChevronRight size={14} className="text-slate-600 ml-auto" />
-                      </button>
-
-                      <div className="space-y-2 pt-2">
-                        {["Projects", "General", "Shared", "Archive"].map((folder, idx) => (
-                          <div
-                            key={idx}
-                            className="flex items-center justify-between p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer"
-                          >
-                            <div className="flex items-center gap-3">
-                              <Folder size={16} className="text-slate-500" />
-                              <span className="text-sm font-medium text-slate-300">{folder}</span>
-                            </div>
-                            <ChevronRight size={14} className="text-slate-600" />
-                          </div>
-                        ))}
-                      </div>
-                    </>
-                  )}
-
-                  {filesContext === "project" && (
-                    <>
-                      <button
-                        onClick={() => setFilesContext("root")}
-                        className="flex items-center gap-2 px-1 py-2 text-sm font-medium text-amber-500 hover:text-amber-400 transition-colors"
-                      >
-                        <ChevronRight size={14} className="rotate-180" />
-                        Back
-                      </button>
-
-                      <div className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg">
-                        <p className="text-xs text-slate-500 uppercase tracking-wider">Project Context</p>
-                        <p className="text-sm font-semibold text-slate-200 mt-2">Contents</p>
-                      </div>
-
-                      <div className="space-y-2 pt-2">
-                        {["Documents", "Assets", "References", "Archive"].map((file, idx) => (
-                          <div key={idx} className="flex items-center justify-between p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer">
-                            <div className="flex items-center gap-3">
-                              <Files size={16} className="text-slate-500" />
-                              <span className="text-sm font-medium text-slate-300">{file}</span>
-                            </div>
-                            <ChevronRight size={14} className="text-slate-600" />
-                          </div>
-                        ))}
-                      </div>
-                    </>
-                  )}
-                </div>
-              )}
-
-              {/* TASKS TAB */}
-              {activeTab === "tasks" && (
-                <div className="space-y-5">
-                  {["My Tasks", "Reviews", "Submissions", "Overdue", "Completed"].map((section, idx) => (
-                    <div key={idx}>
-                      <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">{section}</h3>
-                      <div className="space-y-2">
-                        {[1, 2].map((task) => (
-                          <div key={task} className="flex items-start gap-3 p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer group">
-                            <CheckSquare size={16} className="text-amber-500 mt-0.5 flex-shrink-0" />
-                            <div className="flex-1 min-w-0">
-                              <p className="text-sm font-medium text-slate-200">Task item</p>
-                              <div className="flex items-center gap-2 mt-1.5">
-                                <span className="inline-block px-2 py-0.5 text-xs font-medium bg-amber-500/20 text-amber-300 rounded">Priority</span>
-                              </div>
-                            </div>
-                            <ChevronRight size={14} className="text-slate-600" />
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-
-              {/* ACCOUNT TAB */}
-              {activeTab === "account" && (
-                <div className="space-y-5">
-                  {/* Profile Section */}
-                  <div className="p-4 bg-slate-900/60 border border-slate-800 rounded-lg">
-                    <div className="flex items-center gap-3 mb-4">
-                      <div className="w-12 h-12 bg-slate-800 rounded-full flex items-center justify-center border border-slate-700">
-                        <span className="text-sm font-bold text-amber-500">JD</span>
-                      </div>
-                      <div>
-                        <p className="text-sm font-semibold text-slate-200">User Name</p>
-                        <p className="text-xs text-slate-500">user@email.com</p>
-                      </div>
-                    </div>
-                    <button className="w-full py-2.5 px-3 text-sm font-medium text-amber-500 hover:text-amber-400 transition-colors border border-amber-500/50 rounded-lg hover:bg-amber-500/5">
-                      Edit Profile
-                    </button>
-                  </div>
-
-                  {/* Menu Items */}
-                  <div className="space-y-2">
-                    {[
-                      { icon: User, label: "Profile & Account" },
-                      { icon: BarChart3, label: "Usage & Billing" },
-                      { icon: Download, label: "Downloads" },
-                      { icon: Settings, label: "Settings" },
-                      { icon: HelpCircle, label: "Support & Help" },
-                    ].map((item, idx) => (
-                      <div
-                        key={idx}
-                        className="flex items-center justify-between p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer"
-                      >
-                        <div className="flex items-center gap-3">
-                          <item.icon size={16} className="text-amber-500" />
-                          <span className="text-sm font-medium text-slate-300">{item.label}</span>
-                        </div>
-                        <ChevronRight size={14} className="text-slate-600" />
-                      </div>
-                    ))}
-                  </div>
-
-                  <button className="w-full py-3 px-3 text-sm font-medium text-slate-400 hover:text-slate-300 bg-slate-900/40 hover:bg-slate-800/60 border border-slate-800 rounded-lg transition-colors">
-                    Sign Out
+                    <span className="text-xs font-medium text-slate-300 text-center">{action.label}</span>
                   </button>
-                </div>
-              )}
-            </div>
+                ))}
+              </div>
             </div>
 
-            {/* ─────── BOTTOM NAVIGATION ─────── */}
-            <div className="absolute bottom-0 left-0 right-0 flex justify-around items-center h-20 bg-slate-950/95 border-t border-slate-900/50 backdrop-blur-sm px-2 safe-area-inset-bottom">
-              {[
-                { id: "home", icon: Home, label: "Home" },
-                { id: "projects", icon: FolderOpen, label: "Projects" },
-                { id: "files", icon: Files, label: "Files" },
-                { id: "tasks", icon: CheckSquare, label: "Tasks" },
-                { id: "account", icon: User, label: "Account" },
-              ].map((nav) => (
-                <button
-                  key={nav.id}
-                  onClick={() => setActiveTab(nav.id as Tab)}
-                  className={`flex flex-col items-center justify-center gap-1 py-2 px-2 rounded-lg transition-all text-xs font-medium ${
-                    activeTab === nav.id
-                      ? "text-amber-500 bg-amber-500/10"
-                      : "text-slate-500 hover:text-slate-400 hover:bg-slate-900/50"
-                  }`}
-                >
-                  <nav.icon size={18} />
-                  <span className="text-xs">{nav.label}</span>
-                </button>
-              ))}
+            {/* Pending */}
+            <div>
+              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Pending</h3>
+              <div className="space-y-2">
+                {[1, 2].map((idx) => (
+                  <div key={idx} className="flex items-start gap-3 p-3 bg-slate-900/60 border border-slate-800 rounded-lg">
+                    <div className="w-2 h-2 bg-amber-500 rounded-full mt-1.5 flex-shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-slate-200">Pending item</p>
+                      <p className="text-xs text-slate-500">Action required</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
+
+            {/* Explore/Apps */}
+            <div>
+              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Explore</h3>
+              <div className="space-y-2">
+                {["360 Tours", "Design Studio", "Content Studio"].map((app, idx) => (
+                  <div key={idx} className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <div className="w-2 h-2 bg-amber-500 rounded-full" />
+                        <span className="text-sm font-medium text-slate-300">{app}</span>
+                      </div>
+                      <ChevronRight size={14} className="text-slate-600" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Bottom Navigation - Static */}
+          <div className="absolute bottom-0 left-0 right-0 flex justify-around items-center h-20 bg-slate-950/95 border-t border-slate-900/50 backdrop-blur-sm px-2">
+            {[
+              { icon: Home, label: "Home", active: true },
+              { icon: FolderOpen, label: "Projects" },
+              { icon: Files, label: "Files" },
+              { icon: CheckSquare, label: "Tasks" },
+              { icon: User, label: "Account" },
+            ].map((nav, idx) => (
+              <button
+                key={idx}
+                className={`flex flex-col items-center justify-center gap-1 py-2 px-2 rounded-lg transition-all text-xs font-medium ${
+                  nav.active ? "text-amber-500 bg-amber-500/10" : "text-slate-500 hover:text-slate-400"
+                }`}
+              >
+                <nav.icon size={18} />
+                <span className="text-xs">{nav.label}</span>
+              </button>
+            ))}
           </div>
         </div>
       </div>

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -1,6 +1,26 @@
-import { Home, FolderOpen, Files, CheckSquare, User, Search, Bell, Plus, Star, ChevronRight, Zap, MessageSquare, AlertCircle, MapPin, Camera, Palette, BookOpen } from "lucide-react";
+import { Home, FolderOpen, Files, CheckSquare, User, Search, Bell, Plus, Star, ChevronRight, Zap, MessageSquare, AlertCircle, MapPin, ChevronDown } from "lucide-react";
 
 export default function MobileShellPreview() {
+  const apps = [
+    { label: "Site Walk", icon: MapPin },
+  ];
+
+  // Calculate grid layout based on app count
+  const getGridClass = () => {
+    const count = apps.length;
+    if (count === 1) return "grid grid-cols-1 place-items-center";
+    if (count === 2) return "grid grid-cols-2";
+    if (count === 3) return "grid grid-cols-2";
+    if (count === 4) return "grid grid-cols-2";
+    return "grid grid-cols-2";
+  };
+
+  const workFeedItems = [
+    { label: "Design review requested", source: "Sarah Chen", type: "review", time: "2h ago" },
+    { label: "Contractor uploaded files", source: "Field Team", type: "upload", time: "4h ago" },
+    { label: "Specification update pending", source: "System", type: "submission", time: "1d ago" },
+  ];
+
   return (
     <div className="min-h-screen bg-slate-950 dark flex items-center justify-center p-4">
       {/* Mobile Phone Frame */}
@@ -16,9 +36,9 @@ export default function MobileShellPreview() {
             <p className="text-xs text-amber-400 mt-1">Home screen proof</p>
           </div>
 
-          {/* Top Bar - Enhanced Branding */}
-          <div className="flex items-center justify-between px-4 py-3 bg-slate-950 border-b border-amber-500/20">
-            {/* Logo - Stronger Slate360 Branding */}
+          {/* Top Bar - Premium Slate360 Branding */}
+          <div className="flex items-center justify-between px-4 py-3 bg-slate-950 border-b border-slate-800">
+            {/* Logo */}
             <div className="flex items-center gap-3">
               <div className="relative w-8 h-8">
                 <svg className="w-full h-full" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -32,89 +52,87 @@ export default function MobileShellPreview() {
                   <path d="M12 10L20 14V18L12 22L4 18V14L12 10Z" fill="#D4AF37" />
                 </svg>
               </div>
-              <span className="text-xs font-bold text-amber-300 tracking-widest hidden sm:inline">SLATE360</span>
+              <span className="text-xs font-bold text-slate-200 tracking-widest hidden sm:inline">SLATE360</span>
             </div>
 
             {/* Actions */}
             <div className="flex items-center gap-1">
               <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors">
-                <Search size={18} className="text-slate-400" />
+                <Search size={18} className="text-slate-500" />
               </button>
               <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors relative">
-                <Bell size={18} className="text-slate-400" />
+                <Bell size={18} className="text-slate-500" />
                 <span className="absolute top-1 right-1 w-1.5 h-1.5 bg-amber-500 rounded-full" />
               </button>
-              <div className="w-8 h-8 bg-slate-800 rounded-full flex items-center justify-center border border-amber-500/50">
-                <span className="text-xs font-bold text-amber-500">JD</span>
+              <div className="w-8 h-8 bg-slate-800 rounded-full flex items-center justify-center border border-slate-700">
+                <span className="text-xs font-bold text-slate-300">JD</span>
               </div>
             </div>
           </div>
 
           {/* Content - Home Screen Only */}
-          <div className="flex-1 overflow-y-auto px-3 py-4 pb-24 space-y-6">
-            {/* PRIORITY 1: Subscribed Apps - Horizontal Scrollable Launcher */}
+          <div className="flex-1 overflow-y-auto px-4 py-5 pb-24 space-y-6">
+            {/* SECTION 1: Apps - Premium Grid Container */}
             <div>
-              <h3 className="text-xs font-bold text-amber-300 uppercase tracking-wider mb-3 px-1">Apps</h3>
-              <div className="flex gap-3 overflow-x-auto pb-2 -mx-3 px-3 snap-x snap-mandatory">
-                {[
-                  { label: "Site Walk", icon: MapPin, accent: "from-orange-600 to-orange-700" },
-                  { label: "360 Tours", icon: Camera, accent: "from-cyan-600 to-cyan-700" },
-                  { label: "Design Studio", icon: Palette, accent: "from-purple-600 to-purple-700" },
-                  { label: "Content Studio", icon: BookOpen, accent: "from-emerald-600 to-emerald-700" },
-                ].map((app, idx) => (
-                  <button
-                    key={idx}
-                    className="flex-shrink-0 w-28 aspect-square snap-center"
-                  >
-                    <div className={`h-full w-full bg-gradient-to-br ${app.accent} border border-yellow-600/30 hover:border-amber-500 rounded-xl flex flex-col items-center justify-center gap-2 transition-all hover:shadow-lg hover:shadow-amber-500/30 group`}>
-                      <div className="p-2 bg-white/10 group-hover:bg-white/20 rounded-lg transition-colors">
-                        <app.icon size={18} className="text-white" />
+              <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider mb-3">Apps</h3>
+              <div className="p-4 bg-slate-900/40 border border-slate-800 rounded-xl backdrop-blur-sm">
+                <div className={`gap-3 ${getGridClass()}`}>
+                  {apps.map((app, idx) => (
+                    <button
+                      key={idx}
+                      className="w-full max-w-xs"
+                    >
+                      <div className="aspect-square bg-gradient-to-br from-slate-800 to-slate-850 border border-amber-500/30 hover:border-amber-500/60 rounded-lg flex flex-col items-center justify-center gap-2 transition-all hover:shadow-lg hover:shadow-amber-500/20 group hover:bg-slate-800">
+                        <div className="p-2.5 bg-slate-700/50 group-hover:bg-slate-700 rounded-lg transition-colors">
+                          <app.icon size={20} className="text-slate-300 group-hover:text-amber-400" />
+                        </div>
+                        <span className="text-xs font-medium text-slate-200 text-center">{app.label}</span>
                       </div>
-                      <span className="text-xs font-semibold text-white text-center px-1 line-clamp-2">{app.label}</span>
-                    </div>
+                    </button>
+                  ))}
+                </div>
+                {apps.length < 4 && (
+                  <button className="w-full mt-3 py-2 text-xs font-medium text-slate-500 hover:text-slate-400 transition-colors border border-dashed border-slate-700 hover:border-slate-600 rounded-lg">
+                    Discover more apps
                   </button>
-                ))}
+                )}
               </div>
-              <p className="text-xs text-slate-500 mt-2 px-1">Swipe to see more</p>
             </div>
 
-            {/* PRIORITY 2: Communications & Workflow Feed */}
+            {/* SECTION 2: Work Feed - Communications Oriented */}
             <div>
-              <div className="flex items-center justify-between mb-3 px-1">
-                <h3 className="text-xs font-bold text-amber-300 uppercase tracking-wider">Notifications</h3>
-                <span className="inline-block px-2 py-0.5 text-xs font-semibold bg-amber-500 text-slate-950 rounded-sm">3</span>
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider">Work Feed</h3>
+                <span className="inline-block px-2 py-0.5 text-xs font-semibold bg-slate-800 text-slate-300 rounded">3</span>
               </div>
-              <div className="space-y-2">
-                {[
-                  { label: "Design review requested", source: "Sarah Chen", type: "review", time: "2h ago" },
-                  { label: "Contractor uploaded files", source: "Field Team", type: "upload", time: "4h ago" },
-                  { label: "Specification update pending", source: "System", type: "submission", time: "1d ago" },
-                ].map((item, idx) => (
-                  <div
-                    key={idx}
-                    className="flex items-start gap-3 p-3 bg-slate-900/60 border border-slate-800 hover:bg-slate-800/80 hover:border-amber-500/40 transition-all cursor-pointer"
-                  >
-                    <div className="pt-1 flex-shrink-0">
-                      {item.type === "review" && <AlertCircle size={14} className="text-amber-500" />}
-                      {item.type === "upload" && <MessageSquare size={14} className="text-cyan-400" />}
-                      {item.type === "submission" && <CheckSquare size={14} className="text-emerald-400" />}
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium text-slate-200">{item.label}</p>
-                      <div className="flex items-center justify-between mt-1">
-                        <p className="text-xs text-slate-500">{item.source}</p>
-                        <p className="text-xs text-slate-600">{item.time}</p>
+              <div className="p-3 bg-slate-900/40 border border-slate-800 rounded-xl overflow-hidden">
+                <div className="space-y-2 max-h-40 overflow-y-auto">
+                  {workFeedItems.map((item, idx) => (
+                    <div
+                      key={idx}
+                      className="flex items-start gap-3 p-2.5 bg-slate-800/40 hover:bg-slate-800/70 rounded-lg transition-colors cursor-pointer border border-transparent hover:border-slate-700"
+                    >
+                      <div className="pt-0.5 flex-shrink-0">
+                        {item.type === "review" && <AlertCircle size={14} className="text-slate-400" />}
+                        {item.type === "upload" && <MessageSquare size={14} className="text-slate-400" />}
+                        {item.type === "submission" && <CheckSquare size={14} className="text-slate-400" />}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-xs font-medium text-slate-200">{item.label}</p>
+                        <div className="flex items-center justify-between mt-0.5">
+                          <p className="text-xs text-slate-500">{item.source}</p>
+                          <p className="text-xs text-slate-600">{item.time}</p>
+                        </div>
                       </div>
                     </div>
-                    <ChevronRight size={14} className="text-slate-600 flex-shrink-0 mt-1" />
-                  </div>
-                ))}
+                  ))}
+                </div>
               </div>
             </div>
 
-            {/* PRIORITY 3: Quick Actions - Entitlement Aware */}
+            {/* SECTION 3: Quick Actions - Premium Compact */}
             <div>
-              <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Quick Actions</h3>
+              <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider mb-3">Quick Actions</h3>
               <div className="grid grid-cols-2 gap-3">
                 {[
                   { icon: Plus, label: "New Project" },
@@ -124,10 +142,10 @@ export default function MobileShellPreview() {
                 ].map((action, idx) => (
                   <button
                     key={idx}
-                    className="p-3 bg-slate-900/60 border border-slate-800 hover:border-amber-500/50 rounded-lg transition-all flex flex-col items-center gap-2 hover:bg-slate-800/80 hover:shadow-md"
+                    className="p-3 bg-slate-800/50 border border-slate-700 hover:border-slate-600 hover:bg-slate-800 rounded-lg transition-all flex flex-col items-center gap-2"
                   >
-                    <div className="p-2 bg-amber-500/20 rounded-lg">
-                      <action.icon size={16} className="text-amber-300" />
+                    <div className="p-1.5 bg-slate-700/60 rounded-lg">
+                      <action.icon size={16} className="text-slate-300" />
                     </div>
                     <span className="text-xs font-medium text-slate-300 text-center">{action.label}</span>
                   </button>
@@ -135,31 +153,31 @@ export default function MobileShellPreview() {
               </div>
             </div>
 
-            {/* PRIORITY 4: Pinned Projects - Lower Prominence */}
-            <div className="pt-2">
-              <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2 px-1">Pinned</h3>
-              <div className="space-y-1">
-                {[1, 2, 3].map((idx) => (
-                  <div key={idx} className="flex items-center gap-2 p-2 bg-slate-900/40 border border-slate-800/50 hover:bg-slate-800/60 transition-colors cursor-pointer rounded">
-                    <Star size={12} className="text-slate-600 flex-shrink-0" fill="currentColor" />
-                    <div className="flex-1 min-w-0">
-                      <p className="text-xs font-medium text-slate-400">Project</p>
-                    </div>
-                    <ChevronRight size={12} className="text-slate-700" />
-                  </div>
-                ))}
+            {/* SECTION 4: Projects - With Subtle Toggle */}
+            <div>
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-xs font-bold text-slate-300 uppercase tracking-wider">Projects</h3>
+                <div className="flex items-center gap-1 p-1 bg-slate-800/50 rounded-lg">
+                  <button className="px-2 py-1 text-xs font-medium text-slate-300 bg-slate-700 rounded transition-colors">
+                    Pinned
+                  </button>
+                  <button className="px-2 py-1 text-xs font-medium text-slate-500 hover:text-slate-400 transition-colors">
+                    All
+                  </button>
+                </div>
               </div>
-            </div>
-
-            {/* PRIORITY 5: Quick Search */}
-            <div className="pt-2">
-              <div className="relative">
-                <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-600" />
-                <input
-                  type="text"
-                  placeholder="Search..."
-                  className="w-full pl-10 pr-4 py-2 bg-slate-900/40 border border-slate-800/50 rounded-lg text-xs text-slate-300 placeholder:text-slate-600 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
-                />
+              <div className="p-3 bg-slate-900/40 border border-slate-800 rounded-xl overflow-hidden">
+                <div className="space-y-1.5 max-h-24 overflow-y-auto">
+                  {[1, 2, 3].map((idx) => (
+                    <div key={idx} className="flex items-center gap-2.5 p-2 bg-slate-800/40 hover:bg-slate-800/60 rounded-lg transition-colors cursor-pointer">
+                      <Star size={12} className="text-slate-600 flex-shrink-0" fill="currentColor" />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-xs font-medium text-slate-400">Project name</p>
+                      </div>
+                      <ChevronRight size={12} className="text-slate-600" />
+                    </div>
+                  ))}
+                </div>
               </div>
             </div>
           </div>

--- a/app/preview/mobile-shell/page.tsx
+++ b/app/preview/mobile-shell/page.tsx
@@ -33,127 +33,119 @@ export default function MobileShellPreview() {
   const [filesContext, setFilesContext] = useState<"root" | "project">("root");
 
   return (
-    <div className="min-h-screen bg-slate-900 dark overflow-hidden">
+    <div className="min-h-screen bg-slate-950 dark overflow-hidden">
       {/* Mobile Phone Frame Wrapper */}
       <div className="flex items-center justify-center min-h-screen p-4 dark">
-        <div className="relative w-full max-w-sm bg-slate-950 rounded-3xl shadow-2xl overflow-hidden border-8 border-slate-800" style={{ aspectRatio: "9/19.5" }}>
+        <div className="relative w-full max-w-sm bg-slate-950 rounded-3xl shadow-2xl overflow-hidden border-8 border-slate-900" style={{ aspectRatio: "9/19.5" }}>
           {/* Phone Notch */}
-          <div className="absolute top-0 left-1/2 -translate-x-1/2 w-40 h-7 bg-slate-950 rounded-b-3xl z-50 border-b-2 border-slate-700" />
+          <div className="absolute top-0 left-1/2 -translate-x-1/2 w-40 h-7 bg-slate-950 rounded-b-3xl z-50 border-b-2 border-slate-800" />
 
           {/* Safe Area Container */}
           <div className="h-full w-full flex flex-col bg-slate-950 relative">
             {/* ─────── TOP BAR ─────── */}
-            <div className="flex items-center justify-between px-4 pt-8 pb-3 bg-gradient-to-b from-slate-900 to-slate-950 border-b border-slate-800">
-              {/* Logo */}
+            <div className="flex items-center justify-between px-4 pt-8 pb-4 bg-slate-950 border-b border-slate-900/50 backdrop-blur-sm">
+              {/* Slate360 Logo Mark */}
               <div className="flex items-center gap-2">
-                <div className="w-6 h-6 bg-amber-500 rounded-lg flex items-center justify-center">
-                  <span className="text-xs font-bold text-slate-950">S</span>
-                </div>
-                <span className="text-sm font-bold text-white hidden xs:inline">Slate360</span>
+                <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M12 2L20 6V10L12 14L4 10V6L12 2Z" fill="#D4AF37" opacity="0.8" />
+                  <path d="M12 10L20 14V18L12 22L4 18V14L12 10Z" fill="#D4AF37" />
+                </svg>
+                <span className="text-xs font-bold text-slate-300 hidden xs:inline tracking-widest">SLATE360</span>
               </div>
 
               {/* Search & Actions */}
-              <div className="flex items-center gap-2">
-                <button className="p-2 hover:bg-slate-800 rounded-lg transition-colors">
-                  <Search size={18} className="text-slate-300" />
+              <div className="flex items-center gap-1">
+                <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors">
+                  <Search size={18} className="text-slate-400" />
                 </button>
-                <button className="p-2 hover:bg-slate-800 rounded-lg transition-colors relative">
-                  <Bell size={18} className="text-slate-300" />
-                  <span className="absolute top-1 right-1 w-2 h-2 bg-amber-500 rounded-full" />
+                <button className="p-2 hover:bg-slate-900 rounded-lg transition-colors relative">
+                  <Bell size={18} className="text-slate-400" />
+                  <span className="absolute top-1 right-1 w-1.5 h-1.5 bg-amber-500 rounded-full" />
                 </button>
-                <div className="w-8 h-8 bg-gradient-to-br from-amber-400 to-amber-600 rounded-full flex items-center justify-center">
-                  <span className="text-xs font-bold text-slate-950">JD</span>
+                <div className="w-8 h-8 bg-gradient-to-br from-slate-800 to-slate-900 rounded-full flex items-center justify-center border border-slate-700">
+                  <span className="text-xs font-bold text-amber-500">JD</span>
                 </div>
               </div>
             </div>
 
             {/* ─────── CONTENT AREA ─────── */}
-            <div className="flex-1 overflow-y-auto px-3 py-4 pb-24 scroll-smooth">
+            <div className="flex-1 overflow-y-auto px-3 py-5 pb-24 scroll-smooth space-y-5">
               {/* HOME TAB */}
               {activeTab === "home" && (
-                <div className="space-y-4">
-                  {/* Search Projects */}
+                <div className="space-y-5">
+                  {/* Search */}
                   <div className="relative">
+                    <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" />
                     <input
                       type="text"
-                      placeholder="Search projects..."
+                      placeholder="Find projects..."
                       value={searchQuery}
                       onChange={(e) => setSearchQuery(e.target.value)}
-                      className="w-full px-4 py-2 bg-slate-800 border border-slate-700 rounded-xl text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+                      className="w-full pl-10 pr-4 py-2.5 bg-slate-900/80 border border-slate-800 rounded-xl text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent transition-all"
                     />
                   </div>
 
-                  {/* Pinned Projects */}
+                  {/* Recent & Quick Access */}
                   <div>
-                    <h3 className="text-xs font-semibold text-slate-300 mb-2 uppercase tracking-wider">Pinned Projects</h3>
-                    <div className="space-y-2">
-                      {["Downtown Office Tower", "Riverside Park Condos"].map((project, idx) => (
-                        <div key={idx} className="flex items-center gap-3 p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-colors cursor-pointer">
-                          <Star size={16} className="text-amber-500" fill="currentColor" />
-                          <div className="flex-1 min-w-0">
-                            <p className="text-sm font-medium text-white truncate">{project}</p>
-                            <p className="text-xs text-slate-400">Active • 12 files</p>
-                          </div>
-                          <ChevronRight size={16} className="text-slate-500" />
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-
-                  {/* Quick Actions */}
-                  <div>
-                    <h3 className="text-xs font-semibold text-slate-300 mb-2 uppercase tracking-wider">Quick Actions</h3>
-                    <div className="grid grid-cols-2 gap-2">
+                    <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Quick Access</h3>
+                    <div className="grid grid-cols-2 gap-3">
                       {[
-                        { icon: Plus, label: "New Project", color: "from-amber-500 to-amber-600" },
-                        { icon: FolderOpen, label: "Open Projects", color: "from-blue-500 to-blue-600" },
-                        { icon: Files, label: "Open Files", color: "from-purple-500 to-purple-600" },
-                        { icon: Clock, label: "Resume Work", color: "from-emerald-500 to-emerald-600" },
+                        { icon: Plus, label: "New Project" },
+                        { icon: FolderOpen, label: "Open" },
+                        { icon: Files, label: "Files" },
+                        { icon: Clock, label: "Recent" },
                       ].map((action, idx) => (
                         <button
                           key={idx}
-                          className="p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-all flex flex-col items-center gap-2 group"
+                          className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 hover:border-slate-700 transition-all group"
                         >
-                          <div className={`p-2 bg-gradient-to-br ${action.color} rounded-lg group-hover:scale-110 transition-transform`}>
-                            <action.icon size={16} className="text-white" />
+                          <div className="flex flex-col items-center gap-2">
+                            <div className="p-2 bg-amber-500/20 rounded-lg group-hover:bg-amber-500/30 transition-colors">
+                              <action.icon size={16} className="text-amber-500" />
+                            </div>
+                            <span className="text-xs font-medium text-slate-300">{action.label}</span>
                           </div>
-                          <span className="text-xs font-medium text-slate-300 text-center">{action.label}</span>
                         </button>
                       ))}
                     </div>
                   </div>
 
-                  {/* Notifications & Pending */}
+                  {/* Pinned Projects */}
                   <div>
-                    <h3 className="text-xs font-semibold text-slate-300 mb-2 uppercase tracking-wider">Pending</h3>
+                    <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Pinned</h3>
                     <div className="space-y-2">
-                      {[
-                        { title: "RFI #4521 awaiting response", time: "2 days overdue" },
-                        { title: "Submittal review from contractor", time: "In review" },
-                      ].map((item, idx) => (
-                        <div key={idx} className="flex items-start gap-3 p-3 bg-slate-800/50 border border-slate-700 rounded-lg">
-                          <div className="w-2 h-2 bg-amber-500 rounded-full mt-1.5 flex-shrink-0" />
-                          <div className="flex-1 min-w-0">
-                            <p className="text-sm font-medium text-white">{item.title}</p>
-                            <p className="text-xs text-slate-400">{item.time}</p>
+                      {[1, 2].map((idx) => (
+                        <div key={idx} className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer group">
+                          <div className="flex items-start gap-3">
+                            <Star size={14} className="text-amber-500 mt-0.5 flex-shrink-0" fill="currentColor" />
+                            <div className="flex-1 min-w-0">
+                              <p className="text-sm font-medium text-slate-200">Project item</p>
+                              <p className="text-xs text-slate-500 mt-0.5">Project · Multiple files</p>
+                            </div>
+                            <ChevronRight size={14} className="text-slate-600" />
                           </div>
                         </div>
                       ))}
                     </div>
                   </div>
 
-                  {/* Apps & Tools */}
+                  {/* Available Modules */}
                   <div>
-                    <h3 className="text-xs font-semibold text-slate-300 mb-2 uppercase tracking-wider">Available Apps</h3>
+                    <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Explore</h3>
                     <div className="space-y-2">
                       {[
-                        { name: "Site Walk", icon: MapPin, color: "bg-orange-500/10 border-orange-500/30" },
-                        { name: "Design Studio", icon: Folder, color: "bg-purple-500/10 border-purple-500/30" },
-                        { name: "Content Studio", icon: Files, color: "bg-pink-500/10 border-pink-500/30" },
-                      ].map((app, idx) => (
-                        <div key={idx} className={`flex items-center gap-3 p-3 border rounded-lg ${app.color} cursor-pointer hover:opacity-80 transition-opacity`}>
-                          <app.icon size={16} className="text-slate-300" />
-                          <span className="text-sm font-medium text-slate-300">{app.name}</span>
+                        { label: "360 Tours" },
+                        { label: "Design Studio" },
+                        { label: "Content Studio" },
+                      ].map((item, idx) => (
+                        <div key={idx} className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer">
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-3">
+                              <div className="w-2 h-2 bg-amber-500 rounded-full" />
+                              <span className="text-sm font-medium text-slate-300">{item.label}</span>
+                            </div>
+                            <ChevronRight size={14} className="text-slate-600" />
+                          </div>
                         </div>
                       ))}
                     </div>
@@ -163,43 +155,46 @@ export default function MobileShellPreview() {
 
               {/* PROJECTS TAB */}
               {activeTab === "projects" && (
-                <div className="space-y-4">
+                <div className="space-y-5">
                   <div className="relative">
+                    <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" />
                     <input
                       type="text"
-                      placeholder="Search projects..."
-                      className="w-full px-4 py-2 bg-slate-800 border border-slate-700 rounded-xl text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+                      placeholder="Find projects..."
+                      className="w-full pl-10 pr-4 py-2.5 bg-slate-900/80 border border-slate-800 rounded-xl text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent transition-all"
                     />
                   </div>
 
-                  <div className="space-y-3">
+                  <div className="space-y-5">
                     <div>
-                      <h3 className="text-xs font-semibold text-slate-300 mb-2 uppercase tracking-wider">Pinned</h3>
-                      <div className="flex gap-2 overflow-x-auto pb-2">
-                        {["DTC", "RPC"].map((pin, idx) => (
-                          <div key={idx} className="flex-shrink-0 w-20 aspect-square bg-slate-800 border border-slate-700 rounded-lg flex items-center justify-center">
-                            <Star size={16} className="text-amber-500" fill="currentColor" />
+                      <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Pinned</h3>
+                      <div className="grid grid-cols-3 gap-2">
+                        {[1, 2].map((idx) => (
+                          <div key={idx} className="aspect-square bg-slate-900/60 border border-slate-800 rounded-lg flex items-center justify-center hover:bg-slate-800/80 transition-colors cursor-pointer">
+                            <Star size={16} className="text-amber-500" />
                           </div>
                         ))}
                       </div>
                     </div>
 
-                    {["My Projects", "Team Projects", "Shared / External", "All Accessible"].map((section, idx) => (
+                    {["My Projects", "Team Projects", "Shared", "All Accessible"].map((section, idx) => (
                       <div key={idx}>
-                        <h3 className="text-xs font-semibold text-slate-300 mb-2 uppercase tracking-wider">{section}</h3>
+                        <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">{section}</h3>
                         <div className="space-y-2">
                           {[1, 2].map((item) => (
-                            <div key={item} className="flex items-center justify-between p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-colors cursor-pointer">
-                              <div className="flex items-center gap-3 flex-1 min-w-0">
-                                <div className="w-8 h-8 bg-amber-500/20 rounded flex items-center justify-center">
-                                  <FolderOpen size={14} className="text-amber-500" />
+                            <div key={item} className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer group">
+                              <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-3 flex-1 min-w-0">
+                                  <div className="w-8 h-8 bg-amber-500/15 rounded flex items-center justify-center flex-shrink-0">
+                                    <FolderOpen size={14} className="text-amber-500" />
+                                  </div>
+                                  <div className="min-w-0">
+                                    <p className="text-sm font-medium text-slate-200 truncate">Project</p>
+                                    <p className="text-xs text-slate-500">Multiple files</p>
+                                  </div>
                                 </div>
-                                <div className="min-w-0">
-                                  <p className="text-sm font-medium text-white truncate">Project {section.split(" ")[0]}</p>
-                                  <p className="text-xs text-slate-400">8 files</p>
-                                </div>
+                                <ChevronRight size={14} className="text-slate-600" />
                               </div>
-                              <ChevronRight size={16} className="text-slate-500" />
                             </div>
                           ))}
                         </div>
@@ -208,7 +203,7 @@ export default function MobileShellPreview() {
 
                     <button className="w-full flex items-center justify-center gap-2 py-3 bg-amber-500 hover:bg-amber-600 rounded-lg text-sm font-semibold text-slate-950 transition-colors">
                       <Plus size={16} />
-                      Create Project
+                      Create New
                     </button>
                   </div>
                 </div>
@@ -216,30 +211,32 @@ export default function MobileShellPreview() {
 
               {/* FILES TAB */}
               {activeTab === "files" && (
-                <div className="space-y-4">
+                <div className="space-y-3">
                   {filesContext === "root" && (
                     <>
                       <button
                         onClick={() => setFilesContext("project")}
-                        className="w-full flex items-center gap-3 p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-colors"
+                        className="w-full flex items-center gap-3 p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors"
                       >
-                        <Folder size={18} className="text-amber-500" />
-                        <span className="text-sm font-medium text-white">Projects</span>
-                        <ChevronRight size={16} className="text-slate-500 ml-auto" />
+                        <Folder size={16} className="text-amber-500" />
+                        <span className="text-sm font-medium text-slate-300">Folders</span>
+                        <ChevronRight size={14} className="text-slate-600 ml-auto" />
                       </button>
 
-                      {["General", "Site Walk", "360 Tours", "Design Studio", "Content Studio", "Shared", "Archive / History"].map((folder, idx) => (
-                        <div
-                          key={idx}
-                          className="flex items-center justify-between p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-colors cursor-pointer"
-                        >
-                          <div className="flex items-center gap-3">
-                            <Folder size={18} className="text-slate-400" />
-                            <span className="text-sm font-medium text-white">{folder}</span>
+                      <div className="space-y-2 pt-2">
+                        {["Projects", "General", "Shared", "Archive"].map((folder, idx) => (
+                          <div
+                            key={idx}
+                            className="flex items-center justify-between p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer"
+                          >
+                            <div className="flex items-center gap-3">
+                              <Folder size={16} className="text-slate-500" />
+                              <span className="text-sm font-medium text-slate-300">{folder}</span>
+                            </div>
+                            <ChevronRight size={14} className="text-slate-600" />
                           </div>
-                          <ChevronRight size={16} className="text-slate-500" />
-                        </div>
-                      ))}
+                        ))}
+                      </div>
                     </>
                   )}
 
@@ -247,26 +244,28 @@ export default function MobileShellPreview() {
                     <>
                       <button
                         onClick={() => setFilesContext("root")}
-                        className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-amber-500 hover:text-amber-400 transition-colors"
+                        className="flex items-center gap-2 px-1 py-2 text-sm font-medium text-amber-500 hover:text-amber-400 transition-colors"
                       >
-                        <ChevronRight size={16} className="rotate-180" />
-                        Back to Root
+                        <ChevronRight size={14} className="rotate-180" />
+                        Back
                       </button>
 
-                      <div className="p-3 bg-slate-800/50 border border-slate-700 rounded-lg">
-                        <p className="text-xs text-slate-400 uppercase tracking-wider">Downtown Office Tower</p>
-                        <p className="text-sm font-semibold text-white mt-1">Project Files (24)</p>
+                      <div className="p-3 bg-slate-900/60 border border-slate-800 rounded-lg">
+                        <p className="text-xs text-slate-500 uppercase tracking-wider">Project Context</p>
+                        <p className="text-sm font-semibold text-slate-200 mt-2">Contents</p>
                       </div>
 
-                      {["Drawings", "Specifications", "Permits", "Contracts", "Submittals", "RFIs"].map((file, idx) => (
-                        <div key={idx} className="flex items-center justify-between p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-colors cursor-pointer">
-                          <div className="flex items-center gap-3">
-                            <Files size={18} className="text-slate-400" />
-                            <span className="text-sm font-medium text-white">{file}</span>
+                      <div className="space-y-2 pt-2">
+                        {["Documents", "Assets", "References", "Archive"].map((file, idx) => (
+                          <div key={idx} className="flex items-center justify-between p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer">
+                            <div className="flex items-center gap-3">
+                              <Files size={16} className="text-slate-500" />
+                              <span className="text-sm font-medium text-slate-300">{file}</span>
+                            </div>
+                            <ChevronRight size={14} className="text-slate-600" />
                           </div>
-                          <ChevronRight size={16} className="text-slate-500" />
-                        </div>
-                      ))}
+                        ))}
+                      </div>
                     </>
                   )}
                 </div>
@@ -274,21 +273,21 @@ export default function MobileShellPreview() {
 
               {/* TASKS TAB */}
               {activeTab === "tasks" && (
-                <div className="space-y-4">
-                  {["My Tasks", "Approvals / Reviews", "Contractor Submissions", "Overdue / At Risk", "Recently Completed"].map((section, idx) => (
+                <div className="space-y-5">
+                  {["My Tasks", "Reviews", "Submissions", "Overdue", "Completed"].map((section, idx) => (
                     <div key={idx}>
-                      <h3 className="text-xs font-semibold text-slate-300 mb-2 uppercase tracking-wider">{section}</h3>
+                      <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">{section}</h3>
                       <div className="space-y-2">
                         {[1, 2].map((task) => (
-                          <div key={task} className="flex items-start gap-3 p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-colors cursor-pointer">
-                            <CheckSquare size={18} className="text-slate-400 mt-0.5" />
+                          <div key={task} className="flex items-start gap-3 p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer group">
+                            <CheckSquare size={16} className="text-amber-500 mt-0.5 flex-shrink-0" />
                             <div className="flex-1 min-w-0">
-                              <p className="text-sm font-medium text-white">Task item from {section}</p>
-                              <div className="flex items-center gap-2 mt-1">
-                                <span className="inline-block px-2 py-0.5 text-xs font-medium bg-amber-500/20 text-amber-300 rounded">Due today</span>
+                              <p className="text-sm font-medium text-slate-200">Task item</p>
+                              <div className="flex items-center gap-2 mt-1.5">
+                                <span className="inline-block px-2 py-0.5 text-xs font-medium bg-amber-500/20 text-amber-300 rounded">Priority</span>
                               </div>
                             </div>
-                            <ChevronRight size={16} className="text-slate-500" />
+                            <ChevronRight size={14} className="text-slate-600" />
                           </div>
                         ))}
                       </div>
@@ -299,52 +298,55 @@ export default function MobileShellPreview() {
 
               {/* ACCOUNT TAB */}
               {activeTab === "account" && (
-                <div className="space-y-4">
+                <div className="space-y-5">
                   {/* Profile Section */}
-                  <div className="p-4 bg-slate-800/50 border border-slate-700 rounded-lg">
+                  <div className="p-4 bg-slate-900/60 border border-slate-800 rounded-lg">
                     <div className="flex items-center gap-3 mb-4">
-                      <div className="w-12 h-12 bg-gradient-to-br from-amber-400 to-amber-600 rounded-full flex items-center justify-center">
-                        <span className="text-sm font-bold text-slate-950">JD</span>
+                      <div className="w-12 h-12 bg-slate-800 rounded-full flex items-center justify-center border border-slate-700">
+                        <span className="text-sm font-bold text-amber-500">JD</span>
                       </div>
                       <div>
-                        <p className="text-sm font-semibold text-white">John Doe</p>
-                        <p className="text-xs text-slate-400">john.doe@slate360.com</p>
+                        <p className="text-sm font-semibold text-slate-200">User Name</p>
+                        <p className="text-xs text-slate-500">user@email.com</p>
                       </div>
                     </div>
-                    <button className="w-full py-2 px-3 text-sm font-medium text-amber-500 hover:text-amber-400 transition-colors border border-amber-500/30 rounded-lg">
+                    <button className="w-full py-2.5 px-3 text-sm font-medium text-amber-500 hover:text-amber-400 transition-colors border border-amber-500/50 rounded-lg hover:bg-amber-500/5">
                       Edit Profile
                     </button>
                   </div>
 
                   {/* Menu Items */}
-                  {[
-                    { icon: User, label: "Profile & Organization" },
-                    { icon: BarChart3, label: "Plan & Usage" },
-                    { icon: Download, label: "Downloads & Updates" },
-                    { icon: Settings, label: "Settings" },
-                    { icon: HelpCircle, label: "Help & Support" },
-                  ].map((item, idx) => (
-                    <div
-                      key={idx}
-                      className="flex items-center justify-between p-3 bg-slate-800/50 border border-slate-700 rounded-lg hover:bg-slate-700/50 transition-colors cursor-pointer"
-                    >
-                      <div className="flex items-center gap-3">
-                        <item.icon size={18} className="text-amber-500" />
-                        <span className="text-sm font-medium text-white">{item.label}</span>
+                  <div className="space-y-2">
+                    {[
+                      { icon: User, label: "Profile & Account" },
+                      { icon: BarChart3, label: "Usage & Billing" },
+                      { icon: Download, label: "Downloads" },
+                      { icon: Settings, label: "Settings" },
+                      { icon: HelpCircle, label: "Support & Help" },
+                    ].map((item, idx) => (
+                      <div
+                        key={idx}
+                        className="flex items-center justify-between p-3 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 transition-colors cursor-pointer"
+                      >
+                        <div className="flex items-center gap-3">
+                          <item.icon size={16} className="text-amber-500" />
+                          <span className="text-sm font-medium text-slate-300">{item.label}</span>
+                        </div>
+                        <ChevronRight size={14} className="text-slate-600" />
                       </div>
-                      <ChevronRight size={16} className="text-slate-500" />
-                    </div>
-                  ))}
+                    ))}
+                  </div>
 
-                  <button className="w-full py-3 px-3 text-sm font-medium text-slate-300 hover:text-white bg-slate-800/30 hover:bg-slate-800/50 border border-slate-700 rounded-lg transition-colors">
+                  <button className="w-full py-3 px-3 text-sm font-medium text-slate-400 hover:text-slate-300 bg-slate-900/40 hover:bg-slate-800/60 border border-slate-800 rounded-lg transition-colors">
                     Sign Out
                   </button>
                 </div>
               )}
             </div>
+            </div>
 
             {/* ─────── BOTTOM NAVIGATION ─────── */}
-            <div className="absolute bottom-0 left-0 right-0 flex justify-around items-center h-20 bg-gradient-to-t from-slate-950 to-slate-950/50 border-t border-slate-800 px-2 safe-area-inset-bottom">
+            <div className="absolute bottom-0 left-0 right-0 flex justify-around items-center h-20 bg-slate-950/95 border-t border-slate-900/50 backdrop-blur-sm px-2 safe-area-inset-bottom">
               {[
                 { id: "home", icon: Home, label: "Home" },
                 { id: "projects", icon: FolderOpen, label: "Projects" },
@@ -355,14 +357,14 @@ export default function MobileShellPreview() {
                 <button
                   key={nav.id}
                   onClick={() => setActiveTab(nav.id as Tab)}
-                  className={`flex flex-col items-center justify-center gap-1 py-2 px-3 rounded-lg transition-all ${
+                  className={`flex flex-col items-center justify-center gap-1 py-2 px-2 rounded-lg transition-all text-xs font-medium ${
                     activeTab === nav.id
                       ? "text-amber-500 bg-amber-500/10"
-                      : "text-slate-400 hover:text-slate-300 hover:bg-slate-800/50"
+                      : "text-slate-500 hover:text-slate-400 hover:bg-slate-900/50"
                   }`}
                 >
-                  <nav.icon size={20} />
-                  <span className="text-xs font-medium">{nav.label}</span>
+                  <nav.icon size={18} />
+                  <span className="text-xs">{nav.label}</span>
                 </button>
               ))}
             </div>

--- a/app/preview/page.tsx
+++ b/app/preview/page.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+export default function PreviewHub() {
+  return (
+    <div className="min-h-screen bg-slate-950 dark flex items-center justify-center p-4">
+      <div className="w-full max-w-2xl">
+        {/* Header */}
+        <div className="mb-12">
+          <h1 className="text-3xl font-bold text-slate-100 mb-2">Slate360 Preview Hub</h1>
+          <p className="text-sm text-slate-400">Design previews and component demonstrations</p>
+        </div>
+
+        {/* Preview Cards */}
+        <div className="grid grid-cols-1 gap-4">
+          {/* Mobile Shell Preview */}
+          <Link href="/preview/mobile-shell">
+            <div className="p-6 bg-slate-900/60 border border-slate-800 rounded-lg hover:bg-slate-800/80 hover:border-slate-700 transition-all cursor-pointer group">
+              <div className="flex items-start justify-between">
+                <div className="flex-1">
+                  <h2 className="text-lg font-semibold text-slate-200 group-hover:text-slate-100 transition-colors mb-1">Mobile Shell</h2>
+                  <p className="text-sm text-slate-500">Slate360 mobile app interface preview</p>
+                </div>
+                <div className="w-8 h-8 bg-amber-500/10 rounded flex items-center justify-center group-hover:bg-amber-500/20 transition-colors">
+                  <svg className="w-4 h-4 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </Link>
+        </div>
+
+        {/* Footer Info */}
+        <div className="mt-12 p-4 bg-slate-900/30 border border-slate-800/50 rounded-lg">
+          <p className="text-xs text-slate-500">Preview-only routes. No production data or analytics.</p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### New Features & Routes
- Created a new `/preview/mobile-shell` route and Preview Hub to showcase a mobile-first product experience.
- Implemented a reorganized mobile hierarchy prioritizing Site Walk, active items, quick actions, and pinned projects.

### Design & Branding
- Applied Slate360 premium branding across the shell, replacing legacy teal accents with a unified gold and amber color palette.
- Refined the "Apps" section with a dark glass layout, adaptive grid, and "Coming Soon" labels for upcoming features.
- Standardized visual tokens for notification dots, badges, avatars, and icons to ensure consistent styling.

### Layout & Usability
- Optimized the app grid with a 30% reduction in size and tighter spacing for better fit on mobile screens.
- Unified card styling and border colors across notification items, buttons, and pinned rows.
- Streamlined content and removed complex sections to improve overall usability within the mobile frame.

[v0 Session](https://v0.app/chat/pcHDszBgMLB)