### PR TITLE
feat: complete password reset flow

### DIFF
--- a/app/auth/reset-password/route.ts
+++ b/app/auth/reset-password/route.ts
@@ -1,0 +1,31 @@
+/**
+ * GET /auth/reset-password?token_hash=xxx&type=recovery
+ *
+ * Handles the password-reset link sent by Supabase Auth.
+ * Verifies the OTP token hash (which establishes a session),
+ * then redirects to the reset-password form page.
+ */
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import type { EmailOtpType } from "@supabase/supabase-js";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const token_hash = searchParams.get("token_hash");
+  const type = searchParams.get("type") as EmailOtpType | null;
+
+  if (token_hash && type) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.verifyOtp({ token_hash, type });
+
+    if (!error) {
+      return NextResponse.redirect(`${origin}/reset-password`);
+    }
+
+    console.error("[auth/reset-password] verifyOtp error:", error.message);
+  }
+
+  return NextResponse.redirect(
+    `${origin}/forgot-password?error=reset-link-expired`,
+  );
+}

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -19,7 +19,7 @@ export default function ForgotPasswordPage() {
     setError(null);
 
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: `${window.location.origin}/auth/callback?next=/account/reset-password`,
+      redirectTo: `${window.location.origin}/auth/callback?next=/reset-password`,
     });
 
     if (error) {

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { ArrowRight, Loader2, CheckCircle2, Eye, EyeOff } from "lucide-react";
+
+export default function ResetPasswordPage() {
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [show, setShow] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const router = useRouter();
+  const supabase = createClient();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters.");
+      return;
+    }
+
+    if (password !== confirm) {
+      setError("Passwords do not match.");
+      return;
+    }
+
+    setLoading(true);
+
+    const { error: updateError } = await supabase.auth.updateUser({
+      password,
+    });
+
+    if (updateError) {
+      setError(updateError.message);
+      setLoading(false);
+      return;
+    }
+
+    setDone(true);
+  }
+
+  return (
+    <div className="auth-page">
+      <div className="auth-topbar">
+        <Link href="/">
+          <img
+            src="/uploads/slate360-logo-reversed-v2.svg"
+            alt="Slate360"
+            className="h-7 w-auto"
+          />
+        </Link>
+        <Link
+          href="/login"
+          className="text-sm text-muted-foreground auth-link"
+        >
+          Back to <span className="font-semibold text-primary">Sign in</span>
+        </Link>
+      </div>
+
+      <div className="flex-1 flex items-center justify-center px-4 py-12">
+        <div className="auth-card">
+          {done ? (
+            <div className="text-center">
+              <CheckCircle2 size={48} className="mx-auto mb-4 text-primary" />
+              <h2 className="text-2xl font-black mb-2 text-foreground">
+                Password updated
+              </h2>
+              <p className="text-muted-foreground mb-6">
+                Your password has been reset successfully.
+              </p>
+              <button
+                onClick={() => router.push("/login")}
+                className="auth-btn-primary"
+              >
+                Sign in <ArrowRight size={15} />
+              </button>
+            </div>
+          ) : (
+            <>
+              <div className="mb-8">
+                <h1 className="text-2xl font-black mb-1 text-foreground">
+                  Set a new password
+                </h1>
+                <p className="text-sm text-muted-foreground">
+                  Enter your new password below.
+                </p>
+              </div>
+
+              {error && <div className="auth-error">{error}</div>}
+
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                  <label className="auth-label">New password</label>
+                  <div className="relative">
+                    <input
+                      type={show ? "text" : "password"}
+                      required
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      placeholder="At least 8 characters"
+                      className="auth-input pr-10"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShow(!show)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                      aria-label={show ? "Hide password" : "Show password"}
+                    >
+                      {show ? <EyeOff size={16} /> : <Eye size={16} />}
+                    </button>
+                  </div>
+                </div>
+
+                <div>
+                  <label className="auth-label">Confirm password</label>
+                  <input
+                    type={show ? "text" : "password"}
+                    required
+                    value={confirm}
+                    onChange={(e) => setConfirm(e.target.value)}
+                    placeholder="Re-enter your password"
+                    className="auth-input"
+                  />
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="auth-btn-primary disabled:cursor-not-allowed"
+                >
+                  {loading ? (
+                    <Loader2 size={16} className="animate-spin" />
+                  ) : (
+                    <>
+                      Update password <ArrowRight size={15} />
+                    </>
+                  )}
+                </button>
+              </form>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds the missing password-reset route handler and form page so the forgot-password → email → reset-password flow works end-to-end.

### Changes
- **`app/auth/reset-password/route.ts`** (new) — Server route handler that reads `token_hash` + `type` from the recovery email link, calls `verifyOtp()` to establish a session, and redirects to the form page. On failure, redirects back to `/forgot-password`.
- **`app/reset-password/page.tsx`** (new) — Client page with new-password + confirm fields, show/hide toggle, 8-char minimum validation, calls `supabase.auth.updateUser({ password })`. Uses the same auth-page styling as login/signup/forgot-password.
- **`app/forgot-password/page.tsx`** (fix) — Changed `redirectTo` from `/auth/callback?next=/account/reset-password` (404) to `/auth/callback?next=/reset-password`.

### Two entry paths covered
1. **Token hash flow** (recovery email): `/auth/reset-password?token_hash=...&type=recovery` → route handler → `/reset-password`
2. **PKCE flow** (`resetPasswordForEmail`): `/auth/callback?next=/reset-password` → existing callback → `/reset-password`

### Validation
- `npm run typecheck` — clean
- `npx next build --no-lint` — clean, both routes in route table
- Both files under 300-line limit (31 + 153)