### PR TITLE
fix: disable clob-contract CI gate (deleted source files)

### DIFF
--- a/ops/file-size-baseline.json
+++ b/ops/file-size-baseline.json
@@ -13,7 +13,6 @@
     "app/(dashboard)/project-hub/[projectId]/schedule/page.tsx": 465,
     "app/(dashboard)/project-hub/[projectId]/submittals/page.tsx": 580,
     "app/api/dashboard/widgets/route.ts": 345,
-    "app/api/market/buy/route.ts": 309,
     "app/api/market/scan/route.ts": 396,
     "app/api/slatedrop/folders/route.ts": 334,
     "app/page.tsx": 780,

--- a/ops/release-gates.json
+++ b/ops/release-gates.json
@@ -24,8 +24,9 @@
     },
     {
       "id": "clob-contract",
-      "required": true,
-      "command": "node scripts/ops/check-clob-contract.mjs"
+      "required": false,
+      "command": "node scripts/ops/check-clob-contract.mjs",
+      "disabledReason": "app/api/market/buy/route.ts and lib/market/clob-api.ts were deleted; re-enable when CLOB routes are rebuilt"
     },
     {
       "id": "lint",


### PR DESCRIPTION
## Problem

`verify:release` has been failing on every commit because the `clob-contract` gate (required) runs `check-clob-contract.mjs`, which reads two files that were deleted:
- `app/api/market/buy/route.ts`
- `lib/market/clob-api.ts`

The script throws `ENOENT` immediately, which exits non-zero and blocks all required gates.

## Fix

- **`ops/release-gates.json`**: Set `clob-contract.required` to `false` with a `disabledReason` field explaining the source files are deleted. The gate can be re-enabled when CLOB routes are rebuilt.
- **`ops/file-size-baseline.json`**: Remove the stale `app/api/market/buy/route.ts: 309` entry.

## Validation

`npm run verify:release` now passes: **All required gates passed.**