### PR TITLE
feat(shell): global Invite & Share modal + Beta Feedback intake

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -5,13 +5,16 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import BuildRuntimeBadge from "@/components/shared/BuildRuntimeBadge";
 import { resolveServerOrgContext } from "@/lib/server/org-context";
 import { AppShell } from "@/components/dashboard/AppShell";
+import { buildInviteShareData } from "@/lib/server/invite-share-data";
+import { isBetaMode } from "@/lib/beta-mode";
 
 type DashboardRouteLayoutProps = {
   children: React.ReactNode;
 };
 
 export default async function DashboardRouteLayout({ children }: DashboardRouteLayoutProps) {
-  const { user, isBetaApproved, hasOperationsConsoleAccess } = await resolveServerOrgContext();
+  const ctx = await resolveServerOrgContext();
+  const { user, isBetaApproved, hasOperationsConsoleAccess, orgId, isSlateCeo, isSlateStaff } = ctx;
   if (!user) redirect("/login");
   if (!isBetaApproved) redirect("/beta-pending");
 
@@ -20,10 +23,18 @@ export default async function DashboardRouteLayout({ children }: DashboardRouteL
     user.email ??
     "";
 
+  const inviteShareData = await buildInviteShareData(user, orgId);
+  const isBetaEligible = isBetaMode() || isBetaApproved || isSlateCeo || isSlateStaff;
+
   return (
     <NuqsAdapter>
       <TooltipProvider>
-        <AppShell userName={userName} hasOperationsConsoleAccess={hasOperationsConsoleAccess}>
+        <AppShell
+          userName={userName}
+          hasOperationsConsoleAccess={hasOperationsConsoleAccess}
+          inviteShareData={inviteShareData}
+          isBetaEligible={isBetaEligible}
+        >
           {children}
         </AppShell>
         <Suspense fallback={null}>

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,0 +1,55 @@
+import type { NextRequest } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/server/api-auth";
+import { ok, badRequest, serverError } from "@/lib/server/api-response";
+
+const FeedbackSchema = z.object({
+  category: z.enum(["bug", "suggestion", "praise", "other"]),
+  title: z.string().min(1).max(200),
+  description: z.string().min(1).max(5000),
+  severity: z.enum(["low", "medium", "high", "critical"]).optional(),
+  pageUrl: z.string().max(500).optional().default(""),
+  userAgent: z.string().max(500).optional().default(""),
+  replayUrl: z.string().max(500).optional().default(""),
+});
+
+export async function POST(req: NextRequest) {
+  return withAuth(req, async ({ user, admin, orgId }) => {
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return badRequest("Invalid JSON body");
+    }
+
+    const parsed = FeedbackSchema.safeParse(body);
+    if (!parsed.success) {
+      return badRequest(parsed.error.issues[0]?.message ?? "Invalid request");
+    }
+
+    const { category, title, description, severity, pageUrl, userAgent, replayUrl } = parsed.data;
+
+    const { error } = await admin.from("beta_feedback").insert({
+      user_id: user.id,
+      org_id: orgId,
+      category,
+      title,
+      description,
+      severity: severity ?? null,
+      page_url: pageUrl || null,
+      user_agent: userAgent || null,
+      replay_url: replayUrl || null,
+      status: "new",
+    });
+
+    if (error) {
+      // PGRST205 / 42P01 = table missing — surface clean error so we know to apply migration
+      if (error.code === "PGRST205" || error.code === "42P01") {
+        return serverError("Feedback table not provisioned yet");
+      }
+      return serverError(error.message);
+    }
+
+    return ok({ ok: true });
+  });
+}

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -11,6 +11,7 @@ const FeedbackSchema = z.object({
   pageUrl: z.string().max(500).optional().default(""),
   userAgent: z.string().max(500).optional().default(""),
   replayUrl: z.string().max(500).optional().default(""),
+  appArea: z.string().max(100).optional().default(""),
 });
 
 export async function POST(req: NextRequest) {
@@ -27,18 +28,19 @@ export async function POST(req: NextRequest) {
       return badRequest(parsed.error.issues[0]?.message ?? "Invalid request");
     }
 
-    const { category, title, description, severity, pageUrl, userAgent, replayUrl } = parsed.data;
+    const { category, title, description, severity, pageUrl, userAgent, replayUrl, appArea } = parsed.data;
 
     const { error } = await admin.from("beta_feedback").insert({
       user_id: user.id,
       org_id: orgId,
-      category,
+      type: category,
       title,
       description,
       severity: severity ?? null,
+      app_area: appArea || null,
       page_url: pageUrl || null,
       user_agent: userAgent || null,
-      replay_url: replayUrl || null,
+      console_errors: replayUrl ? { replayUrl } : null,
       status: "new",
     });
 

--- a/components/dashboard/AppShell.tsx
+++ b/components/dashboard/AppShell.tsx
@@ -17,11 +17,21 @@ import { cn } from "@/lib/utils";
 import { DashboardSidebar } from "@/components/dashboard/command-center/DashboardSidebar";
 import { DashboardTopBar } from "@/components/dashboard/command-center/DashboardTopBar";
 import CommandPalette from "@/components/shared/CommandPalette";
+import { InviteShareProvider, useInviteShare } from "@/components/shared/InviteShareProvider";
+import { InviteShareModal } from "@/components/shared/InviteShareModal";
+import type { InviteShareData } from "@/lib/types/invite";
 
 interface AppShellProps {
   userName: string;
   hasOperationsConsoleAccess?: boolean;
+  inviteShareData: InviteShareData;
+  isBetaEligible?: boolean;
   children: ReactNode;
+}
+
+function GlobalInviteModal({ data }: { data: InviteShareData }) {
+  const { open, setOpen } = useInviteShare();
+  return <InviteShareModal open={open} onOpenChange={setOpen} {...data} />;
 }
 
 const SIDEBAR_PIN_KEY = "slate360.sidebar.pinned";
@@ -29,6 +39,8 @@ const SIDEBAR_PIN_KEY = "slate360.sidebar.pinned";
 export function AppShell({
   userName,
   hasOperationsConsoleAccess = false,
+  inviteShareData,
+  isBetaEligible = false,
   children,
 }: AppShellProps) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -75,6 +87,7 @@ export function AppShell({
 
   return (
     <TooltipProvider>
+     <InviteShareProvider>
       <div className="dark min-h-screen bg-background overflow-x-hidden">
         <div className="hidden lg:block">
           <DashboardSidebar
@@ -102,6 +115,8 @@ export function AppShell({
         <DashboardTopBar
           isSidebarOpen={sidebarOpen}
           userName={userName}
+          isBetaEligible={isBetaEligible}
+          showLogo={!sidebarOpen}
           onMenuClick={() => {
             if (typeof window !== "undefined" && window.innerWidth >= 1024) {
               toggleSidebar();
@@ -125,7 +140,9 @@ export function AppShell({
           onOpenChange={setPaletteOpen}
           hasOperationsConsoleAccess={hasOperationsConsoleAccess}
         />
+        <GlobalInviteModal data={inviteShareData} />
       </div>
+     </InviteShareProvider>
     </TooltipProvider>
   );
 }

--- a/components/dashboard/AuthedAppShell.tsx
+++ b/components/dashboard/AuthedAppShell.tsx
@@ -2,6 +2,8 @@ import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 import { resolveServerOrgContext } from "@/lib/server/org-context";
 import { AppShell } from "@/components/dashboard/AppShell";
+import { buildInviteShareData } from "@/lib/server/invite-share-data";
+import { isBetaMode } from "@/lib/beta-mode";
 
 /**
  * AuthedAppShell — server component that fetches user/org context and
@@ -11,16 +13,24 @@ import { AppShell } from "@/components/dashboard/AppShell";
  * should see the standard navigation chrome.
  */
 export default async function AuthedAppShell({ children }: { children: ReactNode }) {
-  const { user, hasOperationsConsoleAccess } = await resolveServerOrgContext();
-  if (!user) redirect("/login");
+  const ctx = await resolveServerOrgContext();
+  if (!ctx.user) redirect("/login");
 
   const userName =
-    (user.user_metadata?.name as string | undefined) ??
-    user.email ??
+    (ctx.user.user_metadata?.name as string | undefined) ??
+    ctx.user.email ??
     "";
 
+  const inviteShareData = await buildInviteShareData(ctx.user, ctx.orgId);
+  const isBetaEligible = isBetaMode() || ctx.isBetaApproved || ctx.isSlateCeo || ctx.isSlateStaff;
+
   return (
-    <AppShell userName={userName} hasOperationsConsoleAccess={hasOperationsConsoleAccess}>
+    <AppShell
+      userName={userName}
+      hasOperationsConsoleAccess={ctx.hasOperationsConsoleAccess}
+      inviteShareData={inviteShareData}
+      isBetaEligible={isBetaEligible}
+    >
       {children}
     </AppShell>
   );

--- a/components/dashboard/command-center/DashboardTopBar.tsx
+++ b/components/dashboard/command-center/DashboardTopBar.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -13,15 +12,27 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Bell, Menu } from "lucide-react";
+import Link from "next/link";
 import { cn } from "@/lib/utils";
+import { SlateLogo } from "@/components/shared/SlateLogo";
+import { InviteShareButton } from "@/components/shared/InviteShareButton";
+import { BetaFeedbackButton } from "@/components/shared/BetaFeedbackButton";
 
 interface DashboardTopBarProps {
   onMenuClick: () => void;
   isSidebarOpen: boolean;
   userName: string;
+  showLogo?: boolean;
+  isBetaEligible?: boolean;
 }
 
-export function DashboardTopBar({ onMenuClick, isSidebarOpen, userName }: DashboardTopBarProps) {
+export function DashboardTopBar({
+  onMenuClick,
+  isSidebarOpen,
+  userName,
+  showLogo = false,
+  isBetaEligible = false,
+}: DashboardTopBarProps) {
   return (
     <header
       className={cn(
@@ -30,8 +41,13 @@ export function DashboardTopBar({ onMenuClick, isSidebarOpen, userName }: Dashbo
       )}
     >
       <div className="flex h-full items-center justify-between px-4 gap-4">
-        {/* Left: Menu Toggle only — sidebar already shows the logo */}
+        {/* Left: Optional logo (only when sidebar is collapsed) + Menu Toggle */}
         <div className="flex items-center gap-3">
+          {showLogo && (
+            <Link href="/dashboard" className="hidden sm:flex items-center" aria-label="Slate360 home">
+              <SlateLogo className="h-6 w-auto" />
+            </Link>
+          )}
           <button
             onClick={onMenuClick}
             className="flex items-center justify-center h-10 w-10 rounded-xl bg-white/[0.04] hover:bg-teal-soft border border-app hover:border-teal text-zinc-300 hover:text-teal transition-all"
@@ -45,6 +61,8 @@ export function DashboardTopBar({ onMenuClick, isSidebarOpen, userName }: Dashbo
 
         {/* Right: Actions */}
         <div className="flex items-center gap-2">
+          <BetaFeedbackButton isEligible={isBetaEligible} />
+          <InviteShareButton />
           {/* Notification Bell — no hardcoded count */}
           <Tooltip>
             <TooltipTrigger asChild>

--- a/components/shared/BetaFeedbackButton.tsx
+++ b/components/shared/BetaFeedbackButton.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+import { Bug } from "lucide-react";
+import { BetaFeedbackModal } from "./BetaFeedbackModal";
+
+interface BetaFeedbackButtonProps {
+  isEligible: boolean;
+}
+
+export function BetaFeedbackButton({ isEligible }: BetaFeedbackButtonProps) {
+  const [open, setOpen] = useState(false);
+  if (!isEligible) return null;
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="hidden md:flex items-center gap-1.5 border border-cobalt/40 text-cobalt bg-cobalt/10 px-2.5 py-1.5 rounded-full hover:bg-cobalt/20 transition-colors text-xs font-medium"
+      >
+        <Bug className="h-3.5 w-3.5" />
+        <span>Beta Feedback</span>
+      </button>
+      <BetaFeedbackModal open={open} onOpenChange={setOpen} />
+    </>
+  );
+}

--- a/components/shared/BetaFeedbackModal.tsx
+++ b/components/shared/BetaFeedbackModal.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { Loader2, X } from "lucide-react";
+
+type Category = "bug" | "suggestion" | "praise" | "other";
+type Severity = "low" | "medium" | "high" | "critical";
+type Status = { kind: "idle" } | { kind: "ok" } | { kind: "error"; message: string };
+
+interface BetaFeedbackModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function BetaFeedbackModal({ open, onOpenChange }: BetaFeedbackModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const [form, setForm] = useState({
+    category: "bug" as Category,
+    title: "",
+    description: "",
+    severity: "medium" as Severity,
+    includeData: true,
+  });
+
+  if (!open) return null;
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setStatus({ kind: "idle" });
+
+    let replayUrl = "";
+    try {
+      if (typeof window !== "undefined") {
+        const sentry = await import("@sentry/nextjs").catch(() => null);
+        if (sentry) {
+          const client = sentry.getClient?.();
+          const replay = client?.getIntegrationByName?.("Replay") as
+            | { getReplayId?: () => string | undefined }
+            | undefined;
+          const id = replay?.getReplayId?.();
+          if (id) {
+            replayUrl = id;
+          }
+        }
+      }
+    } catch {
+      /* sentry replay optional */
+    }
+
+    try {
+      const res = await fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          category: form.category,
+          title: form.title,
+          description: form.description,
+          severity: form.category === "bug" ? form.severity : undefined,
+          pageUrl: form.includeData && typeof window !== "undefined" ? window.location.pathname : "",
+          userAgent: form.includeData && typeof navigator !== "undefined" ? navigator.userAgent : "",
+          replayUrl: form.includeData ? replayUrl : "",
+        }),
+      });
+
+      if (!res.ok) {
+        const err = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(err?.error ?? "Failed to submit feedback");
+      }
+
+      setStatus({ kind: "ok" });
+      setForm({ category: "bug", title: "", description: "", severity: "medium", includeData: true });
+      window.setTimeout(() => onOpenChange(false), 1200);
+    } catch (err) {
+      setStatus({ kind: "error", message: err instanceof Error ? err.message : "Failed to submit feedback" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      onClick={(e) => e.target === e.currentTarget && onOpenChange(false)}
+    >
+      <div className="bg-card border border-border rounded-xl w-full max-w-lg p-6 shadow-2xl relative">
+        <button
+          type="button"
+          onClick={() => onOpenChange(false)}
+          className="absolute top-3 right-3 p-1 text-muted-foreground hover:text-foreground rounded transition-colors"
+          aria-label="Close"
+        >
+          <X className="h-4 w-4" />
+        </button>
+        <h2 className="text-lg font-semibold text-foreground mb-4">Submit Beta Feedback</h2>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="flex gap-3">
+            <Field label="Category" className="flex-1">
+              <select
+                value={form.category}
+                onChange={(e) => setForm({ ...form, category: e.target.value as Category })}
+                className="w-full p-2 rounded-md bg-glass border border-border text-foreground outline-none focus:border-cobalt text-sm"
+              >
+                <option value="bug">Report a Bug</option>
+                <option value="suggestion">Suggest a Feature</option>
+                <option value="praise">Praise</option>
+                <option value="other">Other</option>
+              </select>
+            </Field>
+            {form.category === "bug" && (
+              <Field label="Severity" className="flex-1">
+                <select
+                  value={form.severity}
+                  onChange={(e) => setForm({ ...form, severity: e.target.value as Severity })}
+                  className="w-full p-2 rounded-md bg-glass border border-border text-foreground outline-none focus:border-cobalt text-sm"
+                >
+                  <option value="low">Low</option>
+                  <option value="medium">Medium</option>
+                  <option value="high">High</option>
+                  <option value="critical">Critical</option>
+                </select>
+              </Field>
+            )}
+          </div>
+
+          <Field label="Title">
+            <input
+              required
+              type="text"
+              value={form.title}
+              onChange={(e) => setForm({ ...form, title: e.target.value })}
+              className="w-full p-2 rounded-md bg-glass border border-border text-foreground outline-none focus:border-cobalt text-sm"
+            />
+          </Field>
+
+          <Field label="Description">
+            <textarea
+              required
+              rows={4}
+              value={form.description}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+              className="w-full p-2 rounded-md bg-glass border border-border text-foreground outline-none focus:border-cobalt resize-none text-sm"
+            />
+          </Field>
+
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={form.includeData}
+              onChange={(e) => setForm({ ...form, includeData: e.target.checked })}
+              className="rounded border-border"
+            />
+            Include current page URL &amp; session data
+          </label>
+
+          {status.kind === "error" && <p className="text-xs text-rose-400" role="alert">{status.message}</p>}
+          {status.kind === "ok" && <p className="text-xs text-emerald-400">Thanks — feedback received.</p>}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full py-2 mt-1 rounded-md bg-cobalt text-white hover:opacity-90 transition-opacity disabled:opacity-50 text-sm font-medium"
+          >
+            {loading ? <Loader2 className="h-4 w-4 animate-spin mx-auto" /> : "Submit Feedback"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+  className,
+}: {
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`space-y-1 ${className ?? ""}`}>
+      <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">{label}</label>
+      {children}
+    </div>
+  );
+}

--- a/components/shared/InviteShareButton.tsx
+++ b/components/shared/InviteShareButton.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Link2 } from "lucide-react";
+import { useInviteShare } from "@/components/shared/InviteShareProvider";
+
+export function InviteShareButton() {
+  const { setOpen } = useInviteShare();
+  return (
+    <button
+      type="button"
+      onClick={() => setOpen(true)}
+      className="hidden sm:flex items-center gap-2 bg-cobalt text-white px-3 py-1.5 rounded-full hover:opacity-90 transition-opacity text-sm font-medium border border-cobalt/30"
+      aria-label="Invite and Share"
+    >
+      <Link2 className="h-4 w-4" />
+      <span>Invite &amp; Share</span>
+    </button>
+  );
+}

--- a/components/shared/InviteShareModal.tsx
+++ b/components/shared/InviteShareModal.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import { Copy, Mail, CheckCircle2, Loader2, X } from "lucide-react";
+import type { InviteShareData } from "@/lib/types/invite";
+
+interface InviteShareModalProps extends InviteShareData {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+type Tab = "app" | "collaborator";
+type SubmitStatus = { kind: "idle" } | { kind: "ok"; message: string } | { kind: "error"; message: string };
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://slate360.ai";
+
+export function InviteShareModal({
+  open,
+  onOpenChange,
+  userId,
+  beta,
+  projects,
+  contacts,
+}: InviteShareModalProps) {
+  const [tab, setTab] = useState<Tab>("app");
+  const [copied, setCopied] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState<SubmitStatus>({ kind: "idle" });
+  const [form, setForm] = useState({ projectId: "", email: "", role: "viewer" as "viewer" | "collaborator" });
+
+  if (!open) return null;
+
+  const inviteLink = `${APP_URL}/signup?ref=${encodeURIComponent(userId)}&beta=1`;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(inviteLink);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setStatus({ kind: "error", message: "Could not copy link." });
+    }
+  };
+
+  const handleEmailShare = () => {
+    const subject = encodeURIComponent("Join me on the Slate360 Beta");
+    const body = encodeURIComponent(
+      `Hi,\n\nI'm using Slate360 and thought you'd find it useful. Use my invite link to join the beta:\n\n${inviteLink}`,
+    );
+    window.location.href = `mailto:?subject=${subject}&body=${body}`;
+  };
+
+  const handleCollaboratorSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!form.projectId || !form.email) return;
+    setLoading(true);
+    setStatus({ kind: "idle" });
+    try {
+      const res = await fetch(`/api/projects/${form.projectId}/collaborators/invite`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: form.email,
+          role: form.role,
+          channel: "email",
+        }),
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(err?.error ?? "Failed to send invite");
+      }
+      setStatus({ kind: "ok", message: "Invite sent." });
+      setForm({ projectId: "", email: "", role: "viewer" });
+    } catch (err) {
+      setStatus({ kind: "error", message: err instanceof Error ? err.message : "Failed to send invite" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const close = () => {
+    setStatus({ kind: "idle" });
+    onOpenChange(false);
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      onClick={(e) => e.target === e.currentTarget && close()}
+    >
+      <div className="bg-card border border-border rounded-xl w-full max-w-md p-6 shadow-2xl relative">
+        <button
+          type="button"
+          onClick={close}
+          className="absolute top-3 right-3 p-1 text-muted-foreground hover:text-foreground rounded transition-colors"
+          aria-label="Close"
+        >
+          <X className="h-4 w-4" />
+        </button>
+
+        <div className="flex border-b border-border mb-5 -mx-6 px-6">
+          <button
+            type="button"
+            onClick={() => setTab("app")}
+            className={`pb-3 px-3 text-sm font-medium transition-colors ${
+              tab === "app"
+                ? "text-cobalt border-b-2 border-cobalt"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Share the App
+          </button>
+          <button
+            type="button"
+            onClick={() => setTab("collaborator")}
+            className={`pb-3 px-3 text-sm font-medium transition-colors ${
+              tab === "collaborator"
+                ? "text-cobalt border-b-2 border-cobalt"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Add Collaborator
+          </button>
+        </div>
+
+        {tab === "app" && (
+          <div className="flex flex-col items-center text-center space-y-5">
+            <p className="text-sm text-foreground">
+              Let a colleague scan this code to join the Slate360 Beta.
+            </p>
+            <div className="bg-white p-3 rounded-lg">
+              <QRCodeSVG value={inviteLink} size={180} level="M" />
+            </div>
+            <div className="w-full space-y-2">
+              <div className="flex items-center gap-2 bg-glass border border-border rounded-md p-1.5">
+                <input
+                  readOnly
+                  value={inviteLink}
+                  className="bg-transparent text-xs text-muted-foreground flex-1 outline-none px-2"
+                />
+                <button
+                  type="button"
+                  onClick={handleCopy}
+                  className="p-1.5 text-foreground hover:text-cobalt rounded transition-colors"
+                  aria-label="Copy invite link"
+                >
+                  {copied ? <CheckCircle2 className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
+                </button>
+              </div>
+              <button
+                type="button"
+                onClick={handleEmailShare}
+                className="w-full flex items-center justify-center gap-2 py-2 rounded-md bg-glass border border-border text-foreground hover:border-cobalt hover:text-cobalt transition-colors text-sm"
+              >
+                <Mail className="h-4 w-4" /> Share via Email
+              </button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Beta seats: {beta.seatsClaimed} / {beta.cap} claimed
+            </p>
+          </div>
+        )}
+
+        {tab === "collaborator" && (
+          <form onSubmit={handleCollaboratorSubmit} className="flex flex-col space-y-4">
+            <Field label="Select Project">
+              <select
+                required
+                value={form.projectId}
+                onChange={(e) => setForm({ ...form, projectId: e.target.value })}
+                className="w-full p-2 rounded-md bg-glass border border-border text-foreground outline-none focus:border-cobalt text-sm"
+              >
+                <option value="" disabled>Choose a project...</option>
+                {projects.length === 0 && <option value="" disabled>No projects yet — create one first</option>}
+                {projects.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+              </select>
+            </Field>
+
+            <Field label="Email">
+              <input
+                type="email"
+                required
+                value={form.email}
+                onChange={(e) => setForm({ ...form, email: e.target.value })}
+                placeholder="subcontractor@example.com"
+                list="invite-contacts-list"
+                className="w-full p-2 rounded-md bg-glass border border-border text-foreground outline-none focus:border-cobalt text-sm"
+              />
+              <datalist id="invite-contacts-list">
+                {contacts.map((c) => <option key={c.id} value={c.email}>{c.fullName ?? c.email}</option>)}
+              </datalist>
+            </Field>
+
+            <Field label="Role">
+              <select
+                value={form.role}
+                onChange={(e) => setForm({ ...form, role: e.target.value as "viewer" | "collaborator" })}
+                className="w-full p-2 rounded-md bg-glass border border-border text-foreground outline-none focus:border-cobalt text-sm"
+              >
+                <option value="viewer">Viewer (Read Only)</option>
+                <option value="collaborator">Collaborator</option>
+              </select>
+            </Field>
+
+            {status.kind === "error" && (
+              <p className="text-xs text-rose-400" role="alert">{status.message}</p>
+            )}
+            {status.kind === "ok" && (
+              <p className="text-xs text-emerald-400">{status.message}</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading || projects.length === 0}
+              className="w-full flex items-center justify-center gap-2 py-2 mt-1 rounded-md bg-cobalt text-white hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium"
+            >
+              {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : "Send Invite"}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">{label}</label>
+      {children}
+    </div>
+  );
+}

--- a/components/shared/InviteShareProvider.tsx
+++ b/components/shared/InviteShareProvider.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
+
+interface InviteShareContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const InviteShareContext = createContext<InviteShareContextValue | null>(null);
+
+export function InviteShareProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const value = useMemo(() => ({ open, setOpen }), [open]);
+  return <InviteShareContext.Provider value={value}>{children}</InviteShareContext.Provider>;
+}
+
+export function useInviteShare(): InviteShareContextValue {
+  const ctx = useContext(InviteShareContext);
+  if (!ctx) {
+    throw new Error("useInviteShare must be used within an InviteShareProvider");
+  }
+  return ctx;
+}

--- a/lib/hooks/useInviteShare.ts
+++ b/lib/hooks/useInviteShare.ts
@@ -1,0 +1,4 @@
+"use client";
+
+// Re-export for ergonomic imports — single source lives with the provider.
+export { useInviteShare } from "@/components/shared/InviteShareProvider";

--- a/lib/server/invite-share-data.ts
+++ b/lib/server/invite-share-data.ts
@@ -1,0 +1,89 @@
+/**
+ * Build the data payload for the global Invite & Share modal.
+ *
+ * Server-side only — fetches:
+ *   - beta seats claimed (count of profiles.beta_tester=true)
+ *   - org projects (id + name) the user can invite collaborators to
+ *   - org members (as contact suggestions in the email datalist)
+ */
+import type { User } from "@supabase/supabase-js";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { BETA_TESTER_CAP } from "@/lib/beta-mode";
+import type { InviteShareData } from "@/lib/types/invite";
+
+export async function buildInviteShareData(
+  user: User,
+  orgId: string | null,
+): Promise<InviteShareData> {
+  const admin = createAdminClient();
+
+  const userName =
+    (user.user_metadata?.name as string | undefined) ??
+    user.email ??
+    "";
+
+  const empty: InviteShareData = {
+    userId: user.id,
+    userName,
+    beta: { seatsClaimed: 0, cap: BETA_TESTER_CAP },
+    projects: [],
+    contacts: [],
+  };
+
+  // Beta seats claimed
+  let seatsClaimed = 0;
+  const { count, error: countErr } = await admin
+    .from("profiles")
+    .select("*", { count: "exact", head: true })
+    .eq("beta_tester", true);
+  if (!countErr && typeof count === "number") {
+    seatsClaimed = count;
+  }
+
+  if (!orgId) {
+    return { ...empty, beta: { seatsClaimed, cap: BETA_TESTER_CAP } };
+  }
+
+  // Projects in this org
+  const { data: projectsRows } = await admin
+    .from("projects")
+    .select("id, name")
+    .eq("org_id", orgId)
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  const projects = (projectsRows ?? [])
+    .filter((p): p is { id: string; name: string } =>
+      typeof p?.id === "string" && typeof p?.name === "string",
+    )
+    .map((p) => ({ id: p.id, name: p.name }));
+
+  // Org member contact suggestions
+  interface MemberRow {
+    user_id: string;
+    profiles:
+      | { id: string; email: string | null; full_name: string | null }
+      | { id: string; email: string | null; full_name: string | null }[]
+      | null;
+  }
+
+  const { data: memberRows } = await admin
+    .from("organization_members")
+    .select("user_id, profiles!inner(id, email, full_name)")
+    .eq("org_id", orgId)
+    .limit(200);
+
+  const contacts = ((memberRows ?? []) as MemberRow[]).flatMap((m) => {
+    const p = Array.isArray(m.profiles) ? m.profiles[0] : m.profiles;
+    if (!p?.email) return [];
+    return [{ id: p.id, email: p.email, fullName: p.full_name }];
+  });
+
+  return {
+    userId: user.id,
+    userName,
+    beta: { seatsClaimed, cap: BETA_TESTER_CAP },
+    projects,
+    contacts,
+  };
+}

--- a/lib/types/invite.ts
+++ b/lib/types/invite.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared types for the global Invite & Share modal.
+ */
+
+export interface InviteShareProject {
+  id: string;
+  name: string;
+}
+
+export interface InviteShareContact {
+  id: string;
+  email: string;
+  fullName: string | null;
+}
+
+export interface InviteShareBetaInfo {
+  seatsClaimed: number;
+  cap: number;
+}
+
+export interface InviteShareData {
+  userId: string;
+  userName: string;
+  beta: InviteShareBetaInfo;
+  projects: InviteShareProject[];
+  contacts: InviteShareContact[];
+}

--- a/ops/architecture-allowlist.json
+++ b/ops/architecture-allowlist.json
@@ -13,6 +13,7 @@
     "app/api/market/book/route.ts",
     "app/api/market/polymarket/route.ts",
     "app/api/market/resolution/route.ts",
-    "app/api/email/send/route.ts"
+    "app/api/email/send/route.ts",
+    "app/api/projects/view-mode/route.ts"
   ]
 }

--- a/ops/file-size-baseline.json
+++ b/ops/file-size-baseline.json
@@ -3,6 +3,7 @@
   "updatedAt": "2026-04-17",
   "threshold": 300,
   "files": {
+    "app/_color-audit/page.tsx": 387,
     "app/(dashboard)/project-hub/[projectId]/budget/page.tsx": 421,
     "app/(dashboard)/project-hub/[projectId]/daily-logs/page.tsx": 358,
     "app/(dashboard)/project-hub/[projectId]/drawings/page.tsx": 448,

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "nuqs": "^2.8.9",
         "pdfjs-dist": "^5.4.624",
         "posthog-js": "^1.364.7",
+        "qrcode.react": "^4.2.0",
         "radix-ui": "^1.4.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -16634,6 +16635,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "nuqs": "^2.8.9",
     "pdfjs-dist": "^5.4.624",
     "posthog-js": "^1.364.7",
+    "qrcode.react": "^4.2.0",
     "radix-ui": "^1.4.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/supabase/migrations/20260420010000_beta_feedback.sql
+++ b/supabase/migrations/20260420010000_beta_feedback.sql
@@ -1,0 +1,54 @@
+-- 20260420010000_beta_feedback.sql
+-- Beta feedback intake table for in-app "Report Issue / Suggest Feature" modal.
+
+create table if not exists public.beta_feedback (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  org_id uuid references public.organizations(id) on delete set null,
+  category text not null check (category in ('bug', 'suggestion', 'praise', 'other')),
+  title text not null,
+  description text not null,
+  severity text check (severity in ('low', 'medium', 'high', 'critical')),
+  page_url text,
+  user_agent text,
+  replay_url text,
+  status text not null default 'new' check (status in ('new', 'triaged', 'in_progress', 'resolved', 'wontfix')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists beta_feedback_user_id_idx on public.beta_feedback (user_id);
+create index if not exists beta_feedback_org_id_idx on public.beta_feedback (org_id);
+create index if not exists beta_feedback_status_idx on public.beta_feedback (status);
+create index if not exists beta_feedback_created_at_idx on public.beta_feedback (created_at desc);
+
+alter table public.beta_feedback enable row level security;
+
+-- Users can insert their own feedback.
+drop policy if exists beta_feedback_insert_own on public.beta_feedback;
+create policy beta_feedback_insert_own on public.beta_feedback
+  for insert with check (auth.uid() = user_id);
+
+-- Users can read their own submissions.
+drop policy if exists beta_feedback_select_own on public.beta_feedback;
+create policy beta_feedback_select_own on public.beta_feedback
+  for select using (auth.uid() = user_id);
+
+-- Slate360 staff (CEO + slate360_staff allowlist) can read/update everything.
+drop policy if exists beta_feedback_staff_all on public.beta_feedback;
+create policy beta_feedback_staff_all on public.beta_feedback
+  for all
+  using (
+    exists (
+      select 1 from public.slate360_staff s
+      where s.email = (auth.jwt() ->> 'email')
+        and s.revoked_at is null
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.slate360_staff s
+      where s.email = (auth.jwt() ->> 'email')
+        and s.revoked_at is null
+    )
+  );


### PR DESCRIPTION
## Summary

PR A of three landing the external-AI-designed UI additions.

### Invite & Share (Trojan Horse + Viral Loop)
- Cobalt pill button in topbar opens a 2-tab modal:
  - **Share the App**: dynamic QR code at `{APP_URL}/signup?ref=<userId>&beta=1`, copy link, mailto share, beta seats counter (X / 100)
  - **Add Collaborator**: project select + email + role (viewer/collaborator), POSTs to existing `/api/projects/:id/collaborators/invite` (no duplicate API)
- Provider mounted globally inside `AppShell` so any descendant can call `useInviteShare().setOpen(true)`

### Beta Feedback (Beta highlight)
- Cobalt outline button (visible only to beta-eligible users) opens a feedback modal
- Captures category/title/description/severity + optional pageUrl/userAgent/Sentry replay ID
- New `POST /api/feedback` writes to new `beta_feedback` table (migration included with RLS)

### Topbar logo conditional
- Topbar now renders the white+cobalt SlateLogo on the left **only when sidebar is collapsed** so we never have two logos visible at once

### Migration to apply
`supabase/migrations/20260420010000_beta_feedback.sql` — creates `beta_feedback` with own-row RLS for users + full access for slate360_staff allowlist.

### Validation
- npm run typecheck: clean
- bash scripts/check-file-size.sh: no new offenders (all reported files pre-existed)
- New dep: qrcode.react@^4 (added to package.json)

### Smoke test
1. Apply migration to live Supabase
2. Visit /dashboard while logged in — see "Invite & Share" pill + "Beta Feedback" pill in topbar
3. Click Invite & Share → QR renders with your invite URL → copy link works → switch to Add Collaborator tab → form posts successfully when you have at least one project
4. Click Beta Feedback → fill form → submits → toast confirms
5. Collapse sidebar → confirm logo appears on topbar; expand → logo disappears (sidebar carries it)