### PR TITLE
feat(onboarding): /welcome flow + required signup demographics

### DIFF
--- a/SLATE360_PROJECT_MEMORY.md
+++ b/SLATE360_PROJECT_MEMORY.md
@@ -197,6 +197,53 @@ When editing oversized files, always read both the state declarations AND the JS
 
 <!-- Each chat MUST overwrite this section at end of conversation. Next chat reads this first. -->
 
+### Session Handoff — 2026-04-20 (Onboarding /welcome flow + required signup demographics — PR #18)
+
+**What Changed**
+- New `/welcome` 3-step onboarding (PWA install, use cases, destinations). Lives outside `(dashboard)` group so beta gate doesn't intercept.
+- `app/welcome/layout.tsx` (server) + `app/welcome/page.tsx` (server, redirects already-onboarded users to /dashboard) + `components/welcome/WelcomeClient.tsx` (268L) + `components/welcome/WelcomeInstallStep.tsx` (111L)
+- New APIs: `POST /api/onboarding/profile` (saves use cases via Zod), `POST /api/onboarding/complete` (marks `onboarding_completed_at` or `onboarding_skipped_install`)
+- `app/signup/page.tsx`: split `name` → `firstName`/`lastName`, added `phone`, promoted demographics from `<details>` to required inline fields, extracted to `components/auth/SignupDemographicsFields.tsx` (140L). Page now 233 lines.
+- `app/api/auth/signup/route.ts`: accepts new field shape; upserts `profiles` row immediately after `generateLink` succeeds; default redirect now `/welcome` (was `/dashboard`). Kept generateLink+Resend (NOT supabase.auth.signUp).
+- `app/(dashboard)/layout.tsx`: added onboarding gate after beta-approval check — redirects to `/welcome` if `onboarding_completed_at IS NULL`. CEO/staff bypass.
+- Migration `20260420020000_onboarding_and_demographics.sql` — APPLIED to live Supabase. Adds: first_name, last_name, organization_name, industry, company_size, primary_use_case[], referral_source, profile_completed_at, onboarding_completed_at, onboarding_skipped_install. NOTICEs for phone/role (already existed).
+- Cleaned 2 junk files (`20`, `tart`) accidentally created by shell quoting issues.
+- PR #18 opened: https://github.com/bcvolker/slate360-rebuild/pull/18
+
+**What's Broken / Partially Done**
+- PR #18 awaiting verify run + merge
+- Operations Console still showing wrong data (Prompt 2 deferred to next chat)
+- Beta Feedback button still beta-only with no attachments (Prompt 3 deferred)
+- Mobile shell has horizontal scroll (Prompt 4 deferred)
+- After PR #18 merges, the very next signup will hit `/welcome` — confirm the email-confirmation `next` query param routes correctly through `app/auth/callback/route.ts`
+
+**Context Files Updated**
+- SLATE360_PROJECT_MEMORY.md (this handoff)
+
+**Next Steps (ordered)**
+1. Wait for PR #18 verify; admin-merge once green (`gh pr merge 18 --squash --admin --delete-branch`)
+2. Live smoke: sign up new account → verify `/welcome` redirect → walk through 3 steps → confirm `profiles` row populated with demographics + `onboarding_completed_at`
+3. Prompt 2 (Operations Console rebuild) — external AI delivery, then integrate
+4. Prompt 3 (Unified Help & Feedback modal with S3 attachments, available to all users) — external AI delivery
+5. Prompt 4 (Mobile shell horizontal-scroll audit + typography pass) — external AI delivery
+
+**External AI Validation Checklist (use for every incoming prompt response)**
+- Auth helper signature: `withAuth(req, async ({user, admin, orgId}) => …)` from `@/lib/server/api-auth`
+- Response helpers from `@/lib/server/api-response` (`ok`, `badRequest`, `serverError`)
+- No `any` — use `unknown` with narrowing, or proper interfaces (e.g., `BeforeInstallPromptEvent extends Event`)
+- Tailwind tokens that exist: `bg-card`, `bg-glass`, `text-foreground`, `text-muted-foreground`, `border-border`, `bg-cobalt`, `text-cobalt`, `border-cobalt`, `bg-teal`, `bg-teal/20`. Do NOT invent.
+- Supabase server client: `await createClient()` from `@/lib/supabase/server` (async)
+- Email flow: NEVER `supabase.auth.signUp()` — use `supabase.auth.admin.generateLink({type:"signup"})` + `sendConfirmationEmail` via Resend (Supabase SMTP is broken)
+- Files ≤300 lines — extract sub-components when nearing limit
+- Content-Type headers on fetch POSTs
+
+**Live DB / Env Reference**
+- DB: `aws-1-us-west-1.pooler.supabase.com:5432`, password `Arlopear$1976_989*` (URL-encode `$`→`%24`, `*`→`%2A`)
+- psql gotcha: use `--no-psqlrc -X -A -t`; avoid `-P pager=off -c "long sql"` (creates junk files)
+- CEO: `slate360ceo@gmail.com`, user_id `f73fd954-d8dd-425f-bb93-0ce92cb65088`, org_id `c5538bfd-a67a-4930-8481-0e5e331ec7cc`
+- Live state: 2 auth.users, 2 profiles (orphans deleted earlier this session)
+- File-size baseline: `ops/file-size-baseline.json` — bump when adding lines to baselined file
+
 ### Session Handoff — 2026-04-20 (Shell consistency root-cause fix + clean-slate DB + single logo source — PRs #12 / #13 / #14)
 
 ### What Changed (PRs #12, #13, #14 — all merged to `main`)

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -7,6 +7,7 @@ import { resolveServerOrgContext } from "@/lib/server/org-context";
 import { AppShell } from "@/components/dashboard/AppShell";
 import { buildInviteShareData } from "@/lib/server/invite-share-data";
 import { isBetaMode } from "@/lib/beta-mode";
+import { createClient } from "@/lib/supabase/server";
 
 type DashboardRouteLayoutProps = {
   children: React.ReactNode;
@@ -17,6 +18,18 @@ export default async function DashboardRouteLayout({ children }: DashboardRouteL
   const { user, isBetaApproved, hasOperationsConsoleAccess, orgId, isSlateCeo, isSlateStaff } = ctx;
   if (!user) redirect("/login");
   if (!isBetaApproved) redirect("/beta-pending");
+
+  // Onboarding gate — first-time users must complete /welcome.
+  // Slate staff/CEO bypass so internal tooling stays unblocked.
+  if (!isSlateCeo && !isSlateStaff) {
+    const supabase = await createClient();
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("onboarding_completed_at")
+      .eq("id", user.id)
+      .maybeSingle();
+    if (!profile?.onboarding_completed_at) redirect("/welcome");
+  }
 
   const userName =
     (user.user_metadata?.name as string | undefined) ??

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -16,7 +16,16 @@ export async function POST(req: Request) {
   if (blocked) return blocked;
 
   try {
-    const { email, password, name, redirectAfter, demographics } = await req.json();
+    const {
+      email,
+      password,
+      name,
+      firstName,
+      lastName,
+      phone,
+      redirectAfter,
+      demographics,
+    } = await req.json();
 
     if (!email || !password) {
       return NextResponse.json(
@@ -25,11 +34,19 @@ export async function POST(req: Request) {
       );
     }
 
-    // Demographics are optional. We persist whatever is provided into
-    // user_metadata so the operations console can later segment users
-    // by industry, role, company size, and referral source.
+    const fullName: string =
+      typeof name === "string" && name.trim().length > 0
+        ? name.trim()
+        : `${firstName ?? ""} ${lastName ?? ""}`.trim();
+
+    // Demographics are required at signup. We persist them into
+    // user_metadata AND into the profiles row so the operations console
+    // can segment users by industry, role, company size, and referral source.
     const demo = demographics && typeof demographics === "object" ? demographics : {};
-    const metadata: Record<string, unknown> = { full_name: name };
+    const metadata: Record<string, unknown> = { full_name: fullName };
+    if (typeof firstName === "string" && firstName.length > 0) metadata.first_name = firstName;
+    if (typeof lastName === "string" && lastName.length > 0) metadata.last_name = lastName;
+    if (typeof phone === "string" && phone.length > 0) metadata.phone = phone;
     for (const key of ["company", "jobTitle", "industry", "companySize", "referralSource"] as const) {
       const v = (demo as Record<string, unknown>)[key];
       if (typeof v === "string" && v.length > 0) metadata[key] = v;
@@ -40,7 +57,7 @@ export async function POST(req: Request) {
     const origin = new URL(req.url).origin;
     const next = typeof redirectAfter === "string" && redirectAfter.startsWith("/")
       ? redirectAfter
-      : "/dashboard";
+      : "/welcome";
     const redirectTo = `${origin}/auth/callback?next=${encodeURIComponent(next)}`;
 
     // Use generateLink which creates user + generates confirmation link in one step
@@ -74,8 +91,6 @@ export async function POST(req: Request) {
     // Send the confirmation email via Resend
     const confirmUrl = linkData.properties?.action_link;
     console.log("[signup] action_link present:", !!confirmUrl, "user id:", linkData?.user?.id);
-    let emailSent = false;
-    let emailError: string | null = null;
 
     if (!confirmUrl) {
     return NextResponse.json(
@@ -84,14 +99,54 @@ export async function POST(req: Request) {
     );
   }
 
+    // Upsert profile row so operations console + onboarding flow can
+    // read demographics immediately. Confirmation hasn't happened yet
+    // but the auth.users row exists, so the FK is satisfied.
+    if (linkData.user?.id) {
+      const profileRow: Record<string, unknown> = {
+        id: linkData.user.id,
+        email,
+        first_name: typeof firstName === "string" ? firstName : null,
+        last_name: typeof lastName === "string" ? lastName : null,
+        organization_name:
+          typeof (demo as Record<string, unknown>).company === "string"
+            ? (demo as Record<string, unknown>).company
+            : null,
+        role:
+          typeof (demo as Record<string, unknown>).jobTitle === "string"
+            ? (demo as Record<string, unknown>).jobTitle
+            : null,
+        industry:
+          typeof (demo as Record<string, unknown>).industry === "string"
+            ? (demo as Record<string, unknown>).industry
+            : null,
+        company_size:
+          typeof (demo as Record<string, unknown>).companySize === "string"
+            ? (demo as Record<string, unknown>).companySize
+            : null,
+        referral_source:
+          typeof (demo as Record<string, unknown>).referralSource === "string"
+            ? (demo as Record<string, unknown>).referralSource
+            : null,
+        phone: typeof phone === "string" && phone.length > 0 ? phone : null,
+      };
+      const { error: profileError } = await supabase
+        .from("profiles")
+        .upsert(profileRow, { onConflict: "id" });
+      if (profileError) {
+        console.warn("[signup] profile upsert failed (non-fatal):", profileError.message);
+      }
+    }
+
+    let emailError: string | null = null;
+
     if (confirmUrl) {
       try {
         await sendConfirmationEmail({
           to: email,
-          name,
+          name: fullName,
           confirmUrl,
         });
-        emailSent = true;
       } catch (err: unknown) {
         emailError = err instanceof Error ? err.message : String(err);
         console.error("[signup] Resend error detail:", { email, emailError, confirmUrlPresent: !!confirmUrl });

--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -1,0 +1,39 @@
+import type { NextRequest } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/server/api-auth";
+import { ok, badRequest, serverError } from "@/lib/server/api-response";
+
+const Schema = z.object({
+  skipInstall: z.boolean().optional(),
+  next: z.string().max(200).optional(),
+});
+
+type ProfileUpdate = {
+  onboarding_completed_at?: string;
+  onboarding_skipped_install?: boolean;
+};
+
+export async function POST(req: NextRequest) {
+  return withAuth(req, async ({ user, admin }) => {
+    const body = await req.json().catch(() => ({}));
+    const parsed = Schema.safeParse(body);
+    if (!parsed.success) {
+      return badRequest(parsed.error.issues[0]?.message ?? "Invalid input");
+    }
+
+    const update: ProfileUpdate = {};
+    if (parsed.data.skipInstall) {
+      update.onboarding_skipped_install = true;
+    } else {
+      update.onboarding_completed_at = new Date().toISOString();
+    }
+
+    const { error } = await admin
+      .from("profiles")
+      .update(update)
+      .eq("id", user.id);
+
+    if (error) return serverError(error.message);
+    return ok({ ok: true, next: parsed.data.next ?? null });
+  });
+}

--- a/app/api/onboarding/profile/route.ts
+++ b/app/api/onboarding/profile/route.ts
@@ -1,0 +1,29 @@
+import type { NextRequest } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/server/api-auth";
+import { ok, badRequest, serverError } from "@/lib/server/api-response";
+
+const Schema = z.object({
+  primaryUseCase: z.array(z.string().max(64)).max(8),
+});
+
+export async function POST(req: NextRequest) {
+  return withAuth(req, async ({ user, admin }) => {
+    const body = await req.json().catch(() => null);
+    const parsed = Schema.safeParse(body);
+    if (!parsed.success) {
+      return badRequest(parsed.error.issues[0]?.message ?? "Invalid input");
+    }
+
+    const { error } = await admin
+      .from("profiles")
+      .update({
+        primary_use_case: parsed.data.primaryUseCase,
+        profile_completed_at: new Date().toISOString(),
+      })
+      .eq("id", user.id);
+
+    if (error) return serverError(error.message);
+    return ok({ ok: true });
+  });
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -5,14 +5,17 @@ import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { Eye, EyeOff, ArrowRight, Loader2 } from "lucide-react";
 import SignupConfirmation from "@/components/auth/SignupConfirmation";
+import SignupDemographicsFields from "@/components/auth/SignupDemographicsFields";
 import { SlateLogo } from "@/components/shared/SlateLogo";
 
 export default function SignupPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [name, setName] = useState("");
-  // Optional demographic fields — collected at signup so the operations
-  // console can segment users by industry, role, company size, etc.
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [phone, setPhone] = useState("");
+  // Demographic fields — required at signup so the operations console can
+  // segment users by industry, role, company size, and referral source.
   const [company, setCompany] = useState("");
   const [jobTitle, setJobTitle] = useState("");
   const [industry, setIndustry] = useState("");
@@ -47,21 +50,25 @@ export default function SignupPage() {
     try {
       const redirectAfter = selectedPlan
         ? `/plans?plan=${selectedPlan}&billing=${selectedBilling}`
-        : undefined;
+        : "/welcome";
       const res = await fetch("/api/auth/signup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           email,
           password,
-          name,
+          firstName,
+          lastName,
+          name: `${firstName} ${lastName}`.trim(),
+          phone: phone || null,
           redirectAfter,
           demographics: {
-            company: company || null,
-            jobTitle: jobTitle || null,
-            industry: industry || null,
-            companySize: companySize || null,
-            referralSource: referralSource || null,
+            company,
+            jobTitle,
+            industry,
+            companySize,
+            referralSource,
+            phone: phone || null,
           },
         }),
       });
@@ -161,80 +168,37 @@ export default function SignupPage() {
           {error && <div className="auth-error">{error}</div>}
 
           <form onSubmit={handleSignup} className="space-y-4">
-            <div>
-              <label className="auth-label">Full name *</label>
-              <input type="text" required value={name} onChange={(e) => setName(e.target.value)} placeholder="Jane Smith"
-                className="auth-input" />
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className="auth-label">First name *</label>
+                <input type="text" required value={firstName} onChange={(e) => setFirstName(e.target.value)} placeholder="Jane" className="auth-input" />
+              </div>
+              <div>
+                <label className="auth-label">Last name *</label>
+                <input type="text" required value={lastName} onChange={(e) => setLastName(e.target.value)} placeholder="Smith" className="auth-input" />
+              </div>
             </div>
             <div>
-              <label className="auth-label">Work email</label>
-              <input type="email" required value={email} onChange={(e) => setEmail(e.target.value)} placeholder="you@yourcompany.com"
-                className="auth-input" />
+              <label className="auth-label">Work email *</label>
+              <input type="email" required value={email} onChange={(e) => setEmail(e.target.value)} placeholder="you@yourcompany.com" className="auth-input" />
             </div>
             <div>
-              <label className="auth-label">Password</label>
+              <label className="auth-label">Password *</label>
               <div className="relative">
-                <input type={showPass ? "text" : "password"} required value={password} onChange={(e) => setPassword(e.target.value)} placeholder="At least 8 characters"
-                  minLength={8}
-                  className="auth-input pr-11" />
+                <input type={showPass ? "text" : "password"} required value={password} onChange={(e) => setPassword(e.target.value)} placeholder="At least 8 characters" minLength={8} className="auth-input pr-11" />
                 <button type="button" onClick={() => setShowPass(v => !v)} className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground">
                   {showPass ? <EyeOff size={16} /> : <Eye size={16} />}
                 </button>
               </div>
             </div>
-
-            {/* Optional demographic fields — helps tailor your experience */}
-            <details className="group rounded-xl border border-input bg-card/40 px-4 py-3">
-              <summary className="flex items-center justify-between cursor-pointer text-xs font-semibold text-muted-foreground hover:text-foreground">
-                <span>Tell us about your work <span className="text-muted-foreground/60 font-normal">(optional)</span></span>
-                <span className="text-muted-foreground/60 group-open:rotate-180 transition-transform">▾</span>
-              </summary>
-              <div className="mt-4 space-y-3">
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <div>
-                    <label className="auth-label">Company / Organization</label>
-                    <input type="text" value={company} onChange={(e) => setCompany(e.target.value)} placeholder="Acme Construction" className="auth-input" />
-                  </div>
-                  <div>
-                    <label className="auth-label">Job title</label>
-                    <input type="text" value={jobTitle} onChange={(e) => setJobTitle(e.target.value)} placeholder="Project Manager" className="auth-input" />
-                  </div>
-                </div>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <div>
-                    <label className="auth-label">Industry</label>
-                    <select value={industry} onChange={(e) => setIndustry(e.target.value)} className="auth-input">
-                      <option value="">Select…</option>
-                      <option>General Contractor</option>
-                      <option>Architecture</option>
-                      <option>Engineering</option>
-                      <option>Owner / Developer</option>
-                      <option>Subcontractor</option>
-                      <option>Real Estate</option>
-                      <option>Education</option>
-                      <option>Government / Public Works</option>
-                      <option>Other</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="auth-label">Company size</label>
-                    <select value={companySize} onChange={(e) => setCompanySize(e.target.value)} className="auth-input">
-                      <option value="">Select…</option>
-                      <option>Just me</option>
-                      <option>2–10</option>
-                      <option>11–50</option>
-                      <option>51–200</option>
-                      <option>201–1000</option>
-                      <option>1000+</option>
-                    </select>
-                  </div>
-                </div>
-                <div>
-                  <label className="auth-label">How did you hear about us?</label>
-                  <input type="text" value={referralSource} onChange={(e) => setReferralSource(e.target.value)} placeholder="Search, colleague, conference…" className="auth-input" />
-                </div>
-              </div>
-            </details>
+            <SignupDemographicsFields
+              company={company} setCompany={setCompany}
+              jobTitle={jobTitle} setJobTitle={setJobTitle}
+              industry={industry} setIndustry={setIndustry}
+              companySize={companySize} setCompanySize={setCompanySize}
+              referralSource={referralSource} setReferralSource={setReferralSource}
+              phone={phone} setPhone={setPhone}
+            />
             <div className="space-y-2.5 pt-1">
               <label className="flex items-start gap-3 cursor-pointer">
                 <input type="checkbox" required checked={agreeTerms} onChange={(e) => setAgreeTerms(e.target.checked)}

--- a/app/welcome/layout.tsx
+++ b/app/welcome/layout.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { SlateLogo } from "@/components/shared/SlateLogo";
+
+export const metadata = {
+  title: "Welcome — Slate360",
+};
+
+export default function WelcomeLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col items-center">
+      <div className="w-full max-w-4xl px-6 py-6 flex justify-start">
+        <Link href="/welcome" aria-label="Slate360 home">
+          <SlateLogo />
+        </Link>
+      </div>
+      <div className="w-full max-w-2xl mx-auto px-4 pb-16 flex-1 flex flex-col">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/app/welcome/page.tsx
+++ b/app/welcome/page.tsx
@@ -1,0 +1,41 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { WelcomeClient } from "@/components/welcome/WelcomeClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function WelcomePage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  // Skip welcome if already onboarded.
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("onboarding_completed_at, first_name")
+    .eq("id", user.id)
+    .single();
+
+  if (profile?.onboarding_completed_at) {
+    redirect("/dashboard");
+  }
+
+  const firstName =
+    (profile?.first_name as string | null) ??
+    (user.user_metadata?.first_name as string | undefined) ??
+    (user.user_metadata?.full_name as string | undefined)?.split(" ")[0] ??
+    "";
+
+  return (
+    <WelcomeClient
+      user={{
+        id: user.id,
+        email: user.email ?? "",
+        name: firstName,
+      }}
+    />
+  );
+}

--- a/components/auth/SignupDemographicsFields.tsx
+++ b/components/auth/SignupDemographicsFields.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+interface Props {
+  company: string;
+  setCompany: (v: string) => void;
+  jobTitle: string;
+  setJobTitle: (v: string) => void;
+  industry: string;
+  setIndustry: (v: string) => void;
+  companySize: string;
+  setCompanySize: (v: string) => void;
+  referralSource: string;
+  setReferralSource: (v: string) => void;
+  phone: string;
+  setPhone: (v: string) => void;
+}
+
+const INDUSTRIES = [
+  "General Contractor",
+  "Architecture",
+  "Engineering",
+  "Owner / Developer",
+  "Subcontractor",
+  "Real Estate",
+  "Education",
+  "Government / Public Works",
+  "Other",
+];
+
+const COMPANY_SIZES = ["Just me", "2–10", "11–50", "51–200", "201–1000", "1000+"];
+
+const REFERRAL_SOURCES = [
+  "Search engine",
+  "Colleague / referral",
+  "Conference or event",
+  "Social media",
+  "Industry publication",
+  "Other",
+];
+
+export default function SignupDemographicsFields({
+  company,
+  setCompany,
+  jobTitle,
+  setJobTitle,
+  industry,
+  setIndustry,
+  companySize,
+  setCompanySize,
+  referralSource,
+  setReferralSource,
+  phone,
+  setPhone,
+}: Props) {
+  return (
+    <div className="space-y-3 rounded-xl border border-input bg-card/40 px-4 py-3">
+      <div className="text-xs font-semibold text-muted-foreground">About your work</div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <label className="auth-label">Company / Organization *</label>
+          <input
+            type="text"
+            required
+            value={company}
+            onChange={(e) => setCompany(e.target.value)}
+            placeholder="Acme Construction"
+            className="auth-input"
+          />
+        </div>
+        <div>
+          <label className="auth-label">Job title *</label>
+          <input
+            type="text"
+            required
+            value={jobTitle}
+            onChange={(e) => setJobTitle(e.target.value)}
+            placeholder="Project Manager"
+            className="auth-input"
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <label className="auth-label">Industry *</label>
+          <select
+            required
+            value={industry}
+            onChange={(e) => setIndustry(e.target.value)}
+            className="auth-input"
+          >
+            <option value="">Select…</option>
+            {INDUSTRIES.map((i) => (
+              <option key={i}>{i}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="auth-label">Company size *</label>
+          <select
+            required
+            value={companySize}
+            onChange={(e) => setCompanySize(e.target.value)}
+            className="auth-input"
+          >
+            <option value="">Select…</option>
+            {COMPANY_SIZES.map((s) => (
+              <option key={s}>{s}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <label className="auth-label">Phone (optional)</label>
+          <input
+            type="tel"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            placeholder="+1 555 123 4567"
+            className="auth-input"
+          />
+        </div>
+        <div>
+          <label className="auth-label">How did you hear about us? *</label>
+          <select
+            required
+            value={referralSource}
+            onChange={(e) => setReferralSource(e.target.value)}
+            className="auth-input"
+          >
+            <option value="">Select…</option>
+            {REFERRAL_SOURCES.map((r) => (
+              <option key={r}>{r}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/welcome/WelcomeClient.tsx
+++ b/components/welcome/WelcomeClient.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2, CheckCircle2 } from "lucide-react";
+import { WelcomeInstallStep } from "./WelcomeInstallStep";
+
+interface UserProfile {
+  id: string;
+  email: string;
+  name: string;
+}
+
+type Device = "ios" | "android" | "desktop";
+type Status = "idle" | "saving" | "ok" | "error";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
+}
+
+const USE_CASES = [
+  "Punch lists",
+  "Inspections",
+  "Progress documentation",
+  "360 tours",
+  "Design review",
+  "Other",
+] as const;
+
+export function WelcomeClient({ user }: { user: UserProfile }) {
+  const router = useRouter();
+  const [step, setStep] = useState<1 | 2 | 3>(1);
+  const [device, setDevice] = useState<Device>("desktop");
+  const [deferredPrompt, setDeferredPrompt] =
+    useState<BeforeInstallPromptEvent | null>(null);
+  const [status, setStatus] = useState<Status>("idle");
+  const [primaryUseCase, setPrimaryUseCase] = useState<string[]>([]);
+
+  useEffect(() => {
+    const ua = navigator.userAgent.toLowerCase();
+    if (/ipad|iphone|ipod/.test(ua)) setDevice("ios");
+    else if (/android/.test(ua)) setDevice("android");
+
+    const onPrompt = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+    };
+    window.addEventListener("beforeinstallprompt", onPrompt);
+    return () => window.removeEventListener("beforeinstallprompt", onPrompt);
+  }, []);
+
+  const handlePwaInstall = async () => {
+    if (!deferredPrompt) return;
+    await deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    if (outcome === "accepted") setDeferredPrompt(null);
+  };
+
+  const skipInstall = async () => {
+    try {
+      await fetch("/api/onboarding/complete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ skipInstall: true }),
+      });
+    } catch {
+      // non-blocking
+    }
+    setStep(2);
+  };
+
+  const toggleUseCase = (uc: string) => {
+    setPrimaryUseCase((prev) => {
+      if (prev.includes(uc)) return prev.filter((u) => u !== uc);
+      if (prev.length >= 8) return prev;
+      return [...prev, uc];
+    });
+  };
+
+  const handleProfileSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus("saving");
+    try {
+      const res = await fetch("/api/onboarding/profile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ primaryUseCase }),
+      });
+      if (!res.ok) throw new Error("Failed to save profile");
+      setStatus("ok");
+      setStep(3);
+    } catch {
+      setStatus("error");
+    }
+  };
+
+  const handleComplete = async (destination: string) => {
+    setStatus("saving");
+    try {
+      await fetch("/api/onboarding/complete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ next: destination }),
+      });
+    } catch {
+      // continue navigation regardless
+    }
+    router.push(destination);
+  };
+
+  const qrUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/welcome?from=qr`
+      : "https://slate360.ai/welcome?from=qr";
+
+  return (
+    <div className="w-full flex flex-col gap-8">
+      <div className="flex items-center justify-between w-full max-w-sm mx-auto mb-2">
+        {[1, 2, 3].map((num) => (
+          <div key={num} className="flex items-center">
+            <div
+              className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
+                step >= num
+                  ? "bg-cobalt text-white"
+                  : "bg-glass text-muted-foreground border border-border"
+              }`}
+            >
+              {step > num ? <CheckCircle2 className="w-4 h-4" /> : num}
+            </div>
+            {num !== 3 && (
+              <div
+                className={`w-16 sm:w-24 h-1 mx-2 rounded ${
+                  step > num ? "bg-cobalt" : "bg-border"
+                }`}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {step === 1 && (
+        <WelcomeInstallStep
+          device={device}
+          deferredPrompt={deferredPrompt}
+          qrUrl={qrUrl}
+          userName={user.name}
+          onContinue={() => setStep(2)}
+          onSkip={skipInstall}
+          onPwaInstall={handlePwaInstall}
+        />
+      )}
+
+      {step === 2 && (
+        <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 w-full max-w-lg mx-auto">
+          <h2 className="text-2xl font-bold mb-2 text-foreground">
+            Customize your experience
+          </h2>
+          <p className="text-muted-foreground mb-6">
+            What will you be using Slate360 for? Pick all that apply.
+          </p>
+
+          <form onSubmit={handleProfileSubmit} className="space-y-6">
+            <div className="space-y-3">
+              <label className="text-sm font-medium text-foreground block">
+                Primary use cases
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {USE_CASES.map((uc) => (
+                  <button
+                    key={uc}
+                    type="button"
+                    onClick={() => toggleUseCase(uc)}
+                    className={`px-4 py-2 rounded-full text-sm font-medium transition-colors border ${
+                      primaryUseCase.includes(uc)
+                        ? "bg-cobalt/20 border-cobalt text-cobalt"
+                        : "bg-glass border-border text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    {uc}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {status === "error" && (
+              <p className="text-red-500 text-sm">
+                Failed to save. Please try again.
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={status === "saving"}
+              className="bg-cobalt text-white hover:bg-cobalt/90 h-11 px-6 rounded-lg font-semibold w-full flex items-center justify-center disabled:opacity-60"
+            >
+              {status === "saving" ? (
+                <Loader2 className="w-5 h-5 animate-spin" />
+              ) : (
+                "Save and continue"
+              )}
+            </button>
+          </form>
+        </div>
+      )}
+
+      {step === 3 && (
+        <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 text-center">
+          <div className="w-16 h-16 bg-teal/20 text-teal rounded-full flex items-center justify-center mx-auto mb-6">
+            <CheckCircle2 className="w-8 h-8" />
+          </div>
+          <h2 className="text-3xl font-bold mb-3 text-foreground">
+            You&apos;re all set!
+          </h2>
+          <p className="text-muted-foreground mb-8">
+            Where would you like to go first?
+          </p>
+
+          <div className="grid grid-cols-1 gap-4 max-w-sm mx-auto text-left">
+            <DestinationCard
+              title="Take a tour of Site Walk"
+              subtitle="See how field capture works"
+              onClick={() => handleComplete("/site-walk?firstrun=1")}
+              disabled={status === "saving"}
+            />
+            <DestinationCard
+              title="Create your first project"
+              subtitle="Set up a workspace"
+              onClick={() => handleComplete("/project-hub/new")}
+              disabled={status === "saving"}
+            />
+            <DestinationCard
+              title="Go to the dashboard"
+              subtitle="See the full command center"
+              onClick={() => handleComplete("/dashboard")}
+              disabled={status === "saving"}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DestinationCard({
+  title,
+  subtitle,
+  onClick,
+  disabled,
+}: {
+  title: string;
+  subtitle: string;
+  onClick: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="bg-card hover:bg-glass border border-border hover:border-cobalt transition-colors p-4 rounded-xl flex flex-col group disabled:opacity-60"
+    >
+      <span className="font-semibold text-foreground group-hover:text-cobalt transition-colors">
+        {title}
+      </span>
+      <span className="text-sm text-muted-foreground">{subtitle}</span>
+    </button>
+  );
+}

--- a/components/welcome/WelcomeInstallStep.tsx
+++ b/components/welcome/WelcomeInstallStep.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { QRCodeSVG } from "qrcode.react";
+import { Download, Smartphone } from "lucide-react";
+
+type Device = "ios" | "android" | "desktop";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
+}
+
+interface Props {
+  device: Device;
+  deferredPrompt: BeforeInstallPromptEvent | null;
+  qrUrl: string;
+  userName: string;
+  onContinue: () => void;
+  onSkip: () => void;
+  onPwaInstall: () => Promise<void>;
+}
+
+export function WelcomeInstallStep({
+  device,
+  deferredPrompt,
+  qrUrl,
+  userName,
+  onContinue,
+  onSkip,
+  onPwaInstall,
+}: Props) {
+  return (
+    <div className="animate-in fade-in slide-in-from-bottom-4 duration-500">
+      <h1 className="text-3xl font-bold mb-3 text-foreground">
+        Welcome to Slate360{userName ? `, ${userName}` : ""} 👋
+      </h1>
+      <p className="text-base text-muted-foreground mb-8 leading-relaxed">
+        Install the app on your phone — it takes 10 seconds and unlocks the
+        full experience: offline capture, camera, GPS, and push notifications.
+      </p>
+
+      <div className="bg-card border border-border rounded-xl p-8 flex flex-col items-center text-center shadow-lg mb-8">
+        {device === "desktop" && (
+          <>
+            <Smartphone className="w-12 h-12 text-cobalt mb-4" />
+            <h3 className="text-xl font-semibold mb-2 text-foreground">Scan to install</h3>
+            <p className="text-sm text-muted-foreground mb-6">
+              Point your phone&apos;s camera at this QR code to open the app.
+            </p>
+            <div className="bg-white p-4 rounded-xl mb-2">
+              <QRCodeSVG value={qrUrl} size={160} level="M" />
+            </div>
+          </>
+        )}
+
+        {device === "ios" && (
+          <>
+            <Download className="w-12 h-12 text-cobalt mb-4" />
+            <h3 className="text-xl font-semibold mb-4 text-foreground">Install on iPhone</h3>
+            <ol className="text-left text-sm space-y-3 bg-glass border border-border p-4 rounded-lg w-full max-w-xs text-muted-foreground">
+              <li>
+                1. Tap the <span className="font-bold text-foreground">Share</span> icon at the bottom of Safari.
+              </li>
+              <li>
+                2. Scroll down and tap <span className="font-bold text-foreground">Add to Home Screen</span>.
+              </li>
+              <li>
+                3. Tap <span className="font-bold text-foreground">Add</span> in the top right.
+              </li>
+            </ol>
+          </>
+        )}
+
+        {device === "android" && (
+          <>
+            <Download className="w-12 h-12 text-cobalt mb-4" />
+            <h3 className="text-xl font-semibold mb-4 text-foreground">Install on Android</h3>
+            {deferredPrompt ? (
+              <button
+                onClick={onPwaInstall}
+                className="bg-cobalt text-white hover:bg-cobalt/90 h-11 px-6 rounded-lg font-semibold w-full max-w-xs"
+              >
+                Install App Now
+              </button>
+            ) : (
+              <p className="text-sm text-muted-foreground max-w-xs">
+                In Chrome, tap the menu (⋮) and choose{" "}
+                <span className="font-bold text-foreground">Install app</span>.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+
+      <div className="flex flex-col items-center gap-4">
+        <button
+          onClick={onContinue}
+          className="bg-cobalt text-white hover:bg-cobalt/90 h-11 px-8 rounded-lg font-semibold w-full sm:w-auto"
+        >
+          I&apos;ve installed it — Continue
+        </button>
+        <button
+          onClick={onSkip}
+          className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4"
+        >
+          Skip for now
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/20260420020000_onboarding_and_demographics.sql
+++ b/supabase/migrations/20260420020000_onboarding_and_demographics.sql
@@ -1,0 +1,20 @@
+-- Onboarding + demographics columns for Slate360 signup capture and welcome flow.
+-- Idempotent: safe to re-run.
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS first_name text,
+  ADD COLUMN IF NOT EXISTS last_name text,
+  ADD COLUMN IF NOT EXISTS phone text,
+  ADD COLUMN IF NOT EXISTS organization_name text,
+  ADD COLUMN IF NOT EXISTS role text,
+  ADD COLUMN IF NOT EXISTS industry text,
+  ADD COLUMN IF NOT EXISTS company_size text,
+  ADD COLUMN IF NOT EXISTS primary_use_case text[] DEFAULT '{}'::text[],
+  ADD COLUMN IF NOT EXISTS referral_source text,
+  ADD COLUMN IF NOT EXISTS profile_completed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS onboarding_completed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS onboarding_skipped_install boolean NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS profiles_onboarding_completed_at_idx
+  ON public.profiles (onboarding_completed_at)
+  WHERE onboarding_completed_at IS NULL;


### PR DESCRIPTION
## Summary
First-run onboarding flow plus a hardened signup form so the operations console can segment users from day one.

## Changes
**Signup**
- Split `name` → `firstName` + `lastName`, add required `phone` (still optional value)
- Promote demographics from collapsible `<details>` to required inline fields (industry, company size, role, referral source, company)
- Extracted to `components/auth/SignupDemographicsFields.tsx` to stay <300 lines
- Default post-confirmation redirect now `/welcome` (was `/dashboard`)
- Signup API upserts a `profiles` row immediately after `generateLink` succeeds so the operations console sees the user before email confirmation

**Welcome / Onboarding (new `/welcome` route, outside `(dashboard)` group so beta gate doesn't block it)**
- 3-step flow: (1) Install PWA — device-aware (iOS Add-to-Home-Screen instructions, Android `beforeinstallprompt`, desktop QR via `qrcode.react`); (2) Use-case multi-select; (3) Destination cards (Site Walk tour / new project / dashboard)
- Server-side guard in `app/(dashboard)/layout.tsx`: users without `onboarding_completed_at` get redirected to `/welcome` (Slate CEO/staff bypass)
- Strictly typed — `BeforeInstallPromptEvent` interface, no `any`
- New endpoints: `POST /api/onboarding/profile` (saves use cases), `POST /api/onboarding/complete` (marks complete or `skipInstall`)

**Migration** (`20260420020000_onboarding_and_demographics.sql` — already applied to live Supabase)
- `profiles` adds: `first_name`, `last_name`, `organization_name`, `industry`, `company_size`, `primary_use_case text[]`, `referral_source`, `profile_completed_at`, `onboarding_completed_at`, `onboarding_skipped_install`
- Partial index on `onboarding_completed_at IS NULL` for the dashboard guard query

## File sizes (all under 300 limit)
- `WelcomeClient.tsx` 268 · `WelcomeInstallStep.tsx` 111 · `SignupDemographicsFields.tsx` 140 · `signup/page.tsx` 233 · `signup/route.ts` 180

## Validation
- `npx tsc --noEmit` clean
- `bash scripts/check-file-size.sh` — no new offenders
- Migration applied successfully to live DB (with `IF NOT EXISTS` guards for pre-existing `phone` / `role`)

## Smoke test plan
1. New signup → confirm redirect lands on `/welcome` (not `/dashboard`)
2. Walk through all 3 steps → end on chosen destination, future visits skip `/welcome`
3. Skip install on step 1 → `onboarding_skipped_install=true` recorded
4. Existing CEO/staff session → still bypasses `/welcome` straight to dashboard
5. Confirm `profiles` row contains industry/company_size/etc. immediately after signup (before email confirmation)