### PR TITLE
feat(shell): universal Help & Feedback modal + mobile overflow guard

### DIFF
--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -3,16 +3,45 @@ import { z } from "zod";
 import { withAuth } from "@/lib/server/api-auth";
 import { ok, badRequest, serverError } from "@/lib/server/api-response";
 
-const FeedbackSchema = z.object({
-  category: z.enum(["bug", "suggestion", "praise", "other"]),
-  title: z.string().min(1).max(200),
-  description: z.string().min(1).max(5000),
-  severity: z.enum(["low", "medium", "high", "critical"]).optional(),
-  pageUrl: z.string().max(500).optional().default(""),
-  userAgent: z.string().max(500).optional().default(""),
-  replayUrl: z.string().max(500).optional().default(""),
-  appArea: z.string().max(100).optional().default(""),
+const AttachmentSchema = z.object({
+  url: z.string(),
+  name: z.string(),
+  size: z.number(),
+  contentType: z.string(),
 });
+
+// Universal feedback payload from the in-app Help & Feedback modal.
+// Maps to the live `beta_feedback` schema:
+//   type             -> beta_feedback.type             (bug|feature|ux|performance|other)
+//   severity         -> beta_feedback.severity         (blocker|high|medium|low)
+//   category         -> appended to description (suggestion subtype)
+//   stepsToReproduce -> beta_feedback.steps_to_reproduce
+//   useCase          -> appended to description
+//   pageUrl          -> beta_feedback.page_url
+//   userAgent        -> beta_feedback.user_agent
+//   attachments      -> beta_feedback.console_errors   (jsonb until S3 upload ships)
+const FeedbackSchema = z.object({
+  type: z.enum(["bug", "feature", "other"]),
+  severity: z.enum(["low", "medium", "high", "critical"]).optional(),
+  category: z.string().max(120).optional(),
+  title: z.string().min(3).max(200),
+  description: z.string().min(5).max(5000),
+  pageUrl: z.string().max(2048).optional().default(""),
+  userAgent: z.string().max(1024).optional().default(""),
+  stepsToReproduce: z.string().max(5000).optional(),
+  useCase: z.string().max(1000).optional(),
+  attachments: z.array(AttachmentSchema).optional(),
+  // Legacy callers (older BetaFeedbackButton) used these — keep accepting them.
+  appArea: z.string().max(100).optional(),
+  replayUrl: z.string().max(500).optional(),
+});
+
+// Modal exposes "critical"; the table check constraint expects "blocker".
+function mapSeverity(s: string | undefined): string | null {
+  if (!s) return null;
+  if (s === "critical") return "blocker";
+  return s;
+}
 
 export async function POST(req: NextRequest) {
   return withAuth(req, async ({ user, admin, orgId }) => {
@@ -28,30 +57,55 @@ export async function POST(req: NextRequest) {
       return badRequest(parsed.error.issues[0]?.message ?? "Invalid request");
     }
 
-    const { category, title, description, severity, pageUrl, userAgent, replayUrl, appArea } = parsed.data;
+    const {
+      type,
+      severity,
+      category,
+      title,
+      description,
+      pageUrl,
+      userAgent,
+      stepsToReproduce,
+      useCase,
+      attachments,
+      appArea,
+      replayUrl,
+    } = parsed.data;
+
+    let finalDescription = description;
+    if (type === "feature") {
+      if (category) finalDescription += `\n\n**Category:** ${category}`;
+      if (useCase) finalDescription += `\n\n**Use Case:**\n${useCase}`;
+    }
+
+    const consolePayload: Record<string, unknown> = {};
+    if (attachments && attachments.length > 0) consolePayload.attachments = attachments;
+    if (replayUrl) consolePayload.replayUrl = replayUrl;
 
     const { error } = await admin.from("beta_feedback").insert({
       user_id: user.id,
       org_id: orgId,
-      type: category,
+      type,
       title,
-      description,
-      severity: severity ?? null,
-      app_area: appArea || null,
+      description: finalDescription,
+      severity: type === "bug" ? mapSeverity(severity) : null,
+      app_area: appArea || (pageUrl ? pageUrl.split("?")[0] : null),
       page_url: pageUrl || null,
       user_agent: userAgent || null,
-      console_errors: replayUrl ? { replayUrl } : null,
+      steps_to_reproduce: type === "bug" ? stepsToReproduce ?? null : null,
+      console_errors: Object.keys(consolePayload).length > 0 ? consolePayload : null,
       status: "new",
     });
 
     if (error) {
-      // PGRST205 / 42P01 = table missing — surface clean error so we know to apply migration
       if (error.code === "PGRST205" || error.code === "42P01") {
         return serverError("Feedback table not provisioned yet");
       }
+      console.error("[Feedback Submission Error]", error);
       return serverError(error.message);
     }
 
     return ok({ ok: true });
   });
 }
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -475,3 +475,23 @@
   background: hsl(0 72% 52% / 0.08);
   border-color: hsl(0 72% 52% / 0.24);
 }
+
+/* ── Mobile shell hardening ─────────────────────────────────
+ * Prevents accidental horizontal scroll on phones (which makes
+ * the dashboard feel broken) and keeps the iOS Safari focus-zoom
+ * from triggering on tiny font sizes.
+ */
+html,
+body {
+  overflow-x: hidden;
+}
+
+@media (max-width: 640px) {
+  :root {
+    font-size: 16px;
+  }
+  .text-xs {
+    font-size: 0.8125rem;
+    line-height: 1.25rem;
+  }
+}

--- a/components/dashboard/AppShell.tsx
+++ b/components/dashboard/AppShell.tsx
@@ -128,11 +128,13 @@ export function AppShell({
 
         <main
           className={cn(
-            "pt-16 transition-all duration-300",
+            "pt-16 transition-all duration-300 min-w-0 overflow-x-hidden",
             sidebarOpen ? "lg:pl-64" : "lg:pl-0"
           )}
         >
-          {children}
+          <div className="w-full min-w-0">
+            {children}
+          </div>
         </main>
 
         <CommandPalette

--- a/components/dashboard/command-center/DashboardTopBar.tsx
+++ b/components/dashboard/command-center/DashboardTopBar.tsx
@@ -16,13 +16,14 @@ import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { SlateLogo } from "@/components/shared/SlateLogo";
 import { InviteShareButton } from "@/components/shared/InviteShareButton";
-import { BetaFeedbackButton } from "@/components/shared/BetaFeedbackButton";
+import { HelpFeedbackButton } from "@/components/shared/HelpFeedbackButton";
 
 interface DashboardTopBarProps {
   onMenuClick: () => void;
   isSidebarOpen: boolean;
   userName: string;
   showLogo?: boolean;
+  /** @deprecated retained for backward compatibility; HelpFeedbackButton is universal */
   isBetaEligible?: boolean;
 }
 
@@ -31,7 +32,6 @@ export function DashboardTopBar({
   isSidebarOpen,
   userName,
   showLogo = false,
-  isBetaEligible = false,
 }: DashboardTopBarProps) {
   return (
     <header
@@ -61,7 +61,7 @@ export function DashboardTopBar({
 
         {/* Right: Actions */}
         <div className="flex items-center gap-2">
-          <BetaFeedbackButton isEligible={isBetaEligible} />
+          <HelpFeedbackButton />
           <InviteShareButton />
           {/* Notification Bell — no hardcoded count */}
           <Tooltip>

--- a/components/shared/HelpFeedbackButton.tsx
+++ b/components/shared/HelpFeedbackButton.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useState } from "react";
+import { MessageSquare } from "lucide-react";
+import { HelpFeedbackModal } from "./HelpFeedbackModal";
+
+export function HelpFeedbackButton() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex items-center gap-2 border border-cobalt text-cobalt hover:bg-cobalt/10 px-3 py-1.5 rounded-full transition-colors text-xs sm:text-sm font-medium"
+      >
+        <MessageSquare className="w-4 h-4" />
+        <span className="hidden sm:inline">Help &amp; Feedback</span>
+      </button>
+      <HelpFeedbackModal open={open} onOpenChange={setOpen} />
+    </>
+  );
+}

--- a/components/shared/HelpFeedbackModal.tsx
+++ b/components/shared/HelpFeedbackModal.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Loader2, X, UploadCloud, MessageSquare } from "lucide-react";
+
+type Status = "idle" | "saving" | "ok" | "error";
+type Tab = "bug" | "feature" | "other";
+
+interface FormState {
+  title: string;
+  description: string;
+  severity: "low" | "medium" | "high" | "critical";
+  category: string;
+  stepsToReproduce: string;
+  useCase: string;
+}
+
+const EMPTY_FORM: FormState = {
+  title: "",
+  description: "",
+  severity: "medium",
+  category: "UX improvement",
+  stepsToReproduce: "",
+  useCase: "",
+};
+
+export function HelpFeedbackModal({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [status, setStatus] = useState<Status>("idle");
+  const [tab, setTab] = useState<Tab>("bug");
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [pageUrl, setPageUrl] = useState("");
+  const [userAgent, setUserAgent] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setPageUrl(window.location.pathname + window.location.search);
+    setUserAgent(navigator.userAgent);
+    setStatus("idle");
+    setErrorMessage(null);
+    setForm(EMPTY_FORM);
+  }, [open]);
+
+  if (!open) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus("saving");
+    setErrorMessage(null);
+
+    try {
+      const payload = {
+        type: tab,
+        title: form.title,
+        description: form.description,
+        severity: tab === "bug" ? form.severity : undefined,
+        category: tab === "feature" ? form.category : undefined,
+        pageUrl,
+        userAgent,
+        stepsToReproduce: tab === "bug" ? form.stepsToReproduce : undefined,
+        useCase: tab === "feature" ? form.useCase : undefined,
+        // Attachments are placeholder-only until S3 presigned upload ships.
+        attachments: [] as Array<{ url: string; name: string; size: number; contentType: string }>,
+      };
+
+      const res = await fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error ?? "Submission failed");
+      }
+      setStatus("ok");
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : "Submission failed");
+      setStatus("error");
+    }
+  };
+
+  if (status === "ok") {
+    return (
+      <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+        <div className="bg-card border border-border rounded-xl w-full max-w-md p-8 text-center shadow-2xl">
+          <div className="w-16 h-16 bg-teal/20 text-teal rounded-full flex items-center justify-center mx-auto mb-4">
+            <MessageSquare className="w-8 h-8" />
+          </div>
+          <h2 className="text-2xl font-bold text-foreground mb-2">Thanks — we received it!</h2>
+          <p className="text-muted-foreground mb-6">
+            The team reviews every report within 1 business day.
+          </p>
+          <div className="flex gap-4 justify-center">
+            <button
+              type="button"
+              onClick={() => {
+                setForm(EMPTY_FORM);
+                setStatus("idle");
+              }}
+              className="text-cobalt hover:underline text-sm"
+            >
+              Submit another
+            </button>
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="bg-cobalt text-white px-6 py-2 rounded-lg font-medium hover:bg-cobalt/90"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+      <div className="bg-card border border-border rounded-xl w-full max-w-2xl shadow-2xl flex flex-col max-h-[90vh]">
+        <div className="flex items-center justify-between p-4 border-b border-border bg-glass rounded-t-xl">
+          <div className="flex flex-wrap gap-2">
+            {(["bug", "feature", "other"] as const).map((t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => setTab(t)}
+                className={`px-3 sm:px-4 py-2 rounded-md text-xs sm:text-sm font-medium transition-colors ${
+                  tab === t
+                    ? "bg-cobalt text-white"
+                    : "text-muted-foreground hover:text-foreground hover:bg-card"
+                }`}
+              >
+                {t === "bug" ? "Report a Bug" : t === "feature" ? "Suggest a Feature" : "Other Feedback"}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            className="text-muted-foreground hover:text-foreground p-1"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-6 overflow-y-auto flex-1">
+          <form id="feedback-form" onSubmit={handleSubmit} className="space-y-5">
+            <div className="space-y-1">
+              <label className="text-sm font-medium text-foreground">Title *</label>
+              <input
+                required
+                maxLength={200}
+                value={form.title}
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+                className="w-full p-2.5 rounded-lg bg-glass border border-border text-foreground outline-none focus:border-cobalt"
+                placeholder="Brief summary..."
+              />
+            </div>
+
+            {tab === "bug" && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="space-y-1">
+                  <label className="text-sm font-medium text-foreground">Severity *</label>
+                  <select
+                    value={form.severity}
+                    onChange={(e) =>
+                      setForm({ ...form, severity: e.target.value as FormState["severity"] })
+                    }
+                    className="w-full p-2.5 rounded-lg bg-glass border border-border text-foreground outline-none focus:border-cobalt"
+                  >
+                    <option value="low">Low (Minor visual issue)</option>
+                    <option value="medium">Medium (Annoying, but usable)</option>
+                    <option value="high">High (Core feature broken)</option>
+                    <option value="critical">Critical (App crashing/Data loss)</option>
+                  </select>
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium text-foreground">Page URL</label>
+                  <input
+                    value={pageUrl}
+                    onChange={(e) => setPageUrl(e.target.value)}
+                    className="w-full p-2.5 rounded-lg bg-glass border border-border text-foreground outline-none focus:border-cobalt text-sm"
+                  />
+                </div>
+                <div className="sm:col-span-2 space-y-1">
+                  <label className="text-sm font-medium text-foreground">Steps to Reproduce</label>
+                  <textarea
+                    rows={2}
+                    value={form.stepsToReproduce}
+                    onChange={(e) => setForm({ ...form, stepsToReproduce: e.target.value })}
+                    className="w-full p-2.5 rounded-lg bg-glass border border-border text-foreground outline-none focus:border-cobalt resize-none text-sm"
+                    placeholder={"1. Go to...\n2. Click..."}
+                  />
+                </div>
+              </div>
+            )}
+
+            {tab === "feature" && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="space-y-1">
+                  <label className="text-sm font-medium text-foreground">Category</label>
+                  <select
+                    value={form.category}
+                    onChange={(e) => setForm({ ...form, category: e.target.value })}
+                    className="w-full p-2.5 rounded-lg bg-glass border border-border text-foreground outline-none focus:border-cobalt"
+                  >
+                    <option value="New module">New module/tool</option>
+                    <option value="UX improvement">UX improvement</option>
+                    <option value="Integration">Integration request</option>
+                    <option value="Other">Other</option>
+                  </select>
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium text-foreground">Why do you want this?</label>
+                  <input
+                    value={form.useCase}
+                    onChange={(e) => setForm({ ...form, useCase: e.target.value })}
+                    className="w-full p-2.5 rounded-lg bg-glass border border-border text-foreground outline-none focus:border-cobalt text-sm"
+                    placeholder="It would save me 2 hours a week..."
+                  />
+                </div>
+              </div>
+            )}
+
+            <div className="space-y-1">
+              <label className="text-sm font-medium flex justify-between text-foreground">
+                Description *{" "}
+                <span className="text-xs text-muted-foreground font-normal">Markdown supported</span>
+              </label>
+              <textarea
+                required
+                maxLength={5000}
+                rows={4}
+                value={form.description}
+                onChange={(e) => setForm({ ...form, description: e.target.value })}
+                className="w-full p-2.5 rounded-lg bg-glass border border-border text-foreground outline-none focus:border-cobalt resize-none"
+                placeholder="Provide as much detail as possible..."
+              />
+            </div>
+
+            <div className="p-4 border border-dashed border-border rounded-xl bg-glass flex flex-col items-center justify-center text-center">
+              <UploadCloud className="w-6 h-6 text-muted-foreground mb-2" />
+              <p className="text-sm text-foreground font-medium">Attach files (Coming Soon)</p>
+              <p className="text-xs text-muted-foreground">Up to 5 files, ≤10MB each</p>
+            </div>
+
+            {status === "error" && (
+              <p className="text-red-500 text-sm">
+                {errorMessage ?? "Failed to submit feedback. Please try again."}
+              </p>
+            )}
+          </form>
+        </div>
+
+        <div className="p-4 border-t border-border bg-glass flex justify-end gap-3 rounded-b-xl">
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            className="px-4 py-2 rounded-lg text-sm font-medium text-foreground hover:bg-card border border-border"
+          >
+            Cancel
+          </button>
+          <button
+            form="feedback-form"
+            type="submit"
+            disabled={status === "saving"}
+            className="bg-cobalt text-white px-6 py-2 rounded-lg text-sm font-medium hover:bg-cobalt/90 flex items-center gap-2 disabled:opacity-60"
+          >
+            {status === "saving" && <Loader2 className="w-4 h-4 animate-spin" />}
+            Submit Report
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Two adjacent fixes from the user-reported "business standstill" list:
1. **Universal Help & Feedback** — replaces the beta-gated feedback button with one available to every authenticated user, with proper bug / feature / other tabs.
2. **Mobile shell hardening** — kills the horizontal scroll on phones and prevents iOS Safari focus-zoom on tiny text.

## Changes

### Help & Feedback
- New `components/shared/HelpFeedbackButton.tsx` (23L) and `HelpFeedbackModal.tsx` (283L)
- `DashboardTopBar` now mounts `HelpFeedbackButton` instead of `BetaFeedbackButton` (deprecated `isBetaEligible` prop kept for backward compatibility)
- Modal tabs: **Report a Bug** (severity + page URL + steps to reproduce), **Suggest a Feature** (category + use case), **Other Feedback**
- Attachment slot present as "Coming Soon" placeholder; payload already accepts `attachments[]` so once S3 presigned uploads ship the modal swap is one-line
- `app/api/feedback/route.ts` rewritten to accept the richer schema; preserves legacy `appArea` / `replayUrl` fields so any existing callers keep working

### Schema mapping (live `beta_feedback` table)
Verified against live DB: table uses `type` / `severity` / `app_area` / `steps_to_reproduce` / `console_errors` (jsonb) — NOT the migration's `category` / `replay_url`. Mapping:
- modal `type` (bug/feature/other) → `type` column directly (constraint allows bug|feature|ux|performance|other)
- modal `severity: "critical"` → `"blocker"` (constraint allows blocker|high|medium|low)
- modal `category` + `useCase` → appended to description as markdown
- modal `attachments[]` → `console_errors` jsonb until S3 presigned uploads ship
- modal `pageUrl` → `page_url`, with `app_area` derived from path

### Mobile shell
- `AppShell` `<main>`: added `min-w-0 overflow-x-hidden`, wrapped children in `w-full min-w-0` div
- `globals.css`: `html, body { overflow-x: hidden }` + `@media (max-width: 640px)` bumps base font to 16px and text-xs to 0.8125rem to avoid iOS focus-zoom

## Validation
- `npx tsc --noEmit` clean
- `bash scripts/check-file-size.sh` — no new offenders (HelpFeedbackModal 283L, all under 300)
- Schema verified against live DB columns and check constraints

## Smoke test plan
1. Click Help & Feedback in topbar (any authenticated user, any tier) → modal opens
2. Submit a bug → check `beta_feedback` row created with `type='bug'`, `severity` mapped, `steps_to_reproduce` populated
3. Submit a feature with use case → description contains `**Use Case:**` block
4. Resize browser to 375px width on /dashboard → no horizontal scrollbar, no overflowing widgets
5. Open on iPhone Safari, focus a text input with 14px or smaller text → no auto-zoom
6. Verify CEO/staff view shows the new submission in operations console (read path unchanged)

## Notes
- `BetaFeedbackButton.tsx` left in place but no longer imported anywhere; safe to delete in a follow-up cleanup PR
- This branches off `main`, not PR #18, so the two PRs can land independently