### PR TITLE
feat(ops): Operations Console Phase 1 — 15-tab shell + Users & Orgs engines

### DIFF
--- a/app/(dashboard)/operations-console/page.tsx
+++ b/app/(dashboard)/operations-console/page.tsx
@@ -1,6 +1,6 @@
 import { notFound, redirect } from "next/navigation";
 import { resolveServerOrgContext } from "@/lib/server/org-context";
-import OperationsConsoleClient from "@/components/dashboard/OperationsConsoleClient";
+import OperationsConsoleClient from "@/components/dashboard/operations/OperationsConsoleClient";
 
 export const metadata = {
   title: "Operations Console — Slate360",

--- a/app/api/operations/feedback/[id]/status/route.ts
+++ b/app/api/operations/feedback/[id]/status/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest } from "next/server";
+import { withAuth } from "@/lib/server/api-auth";
+import { resolveServerOrgContext } from "@/lib/server/org-context";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { ok, badRequest, forbidden, serverError } from "@/lib/server/api-response";
+
+export const dynamic = "force-dynamic";
+
+const ALLOWED_STATUSES = [
+  "new",
+  "triaged",
+  "in_progress",
+  "resolved",
+  "wont_fix",
+  "duplicate",
+] as const;
+type FeedbackStatus = (typeof ALLOWED_STATUSES)[number];
+
+function isAllowedStatus(s: unknown): s is FeedbackStatus {
+  return typeof s === "string" && (ALLOWED_STATUSES as readonly string[]).includes(s);
+}
+
+export const POST = (
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) =>
+  withAuth(req, async () => {
+    const { canAccessOperationsConsole } = await resolveServerOrgContext();
+    if (!canAccessOperationsConsole) return forbidden("Operations Console access required");
+
+    const { id } = await context.params;
+    if (!id) return badRequest("Missing feedback id");
+
+    const body = (await req.json().catch(() => null)) as { status?: unknown } | null;
+    if (!body || !isAllowedStatus(body.status)) {
+      return badRequest(
+        `status is required and must be one of: ${ALLOWED_STATUSES.join(", ")}`,
+      );
+    }
+
+    const admin = createAdminClient();
+    const updates: Record<string, string> = { status: body.status };
+    if (body.status === "resolved") updates.resolved_at = new Date().toISOString();
+
+    const { error } = await admin.from("beta_feedback").update(updates).eq("id", id);
+
+    if (error) {
+      console.error("[/api/operations/feedback/[id]/status] supabase error:", error);
+      return serverError("Failed to update status");
+    }
+
+    return ok({ success: true, status: body.status });
+  });

--- a/app/api/operations/feedback/route.ts
+++ b/app/api/operations/feedback/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest } from "next/server";
+import { withAuth } from "@/lib/server/api-auth";
+import { resolveServerOrgContext } from "@/lib/server/org-context";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { ok, forbidden } from "@/lib/server/api-response";
+
+export const dynamic = "force-dynamic";
+
+type FeedbackStatus = "new" | "triaged" | "in_progress" | "resolved" | "wont_fix" | "duplicate";
+
+interface FeedbackRow {
+  id: string;
+  user_id: string | null;
+  type: string;
+  severity: string | null;
+  title: string;
+  description: string;
+  status: FeedbackStatus;
+  created_at: string;
+}
+
+interface ProfileRow {
+  id: string;
+  email: string | null;
+  first_name: string | null;
+  last_name: string | null;
+}
+
+function mapTypeToCategory(type: string): "bug" | "suggestion" | "other" {
+  if (type === "bug") return "bug";
+  if (type === "feature") return "suggestion";
+  return "other";
+}
+
+function fullName(p: ProfileRow | undefined): string | null {
+  if (!p) return null;
+  const name = [p.first_name, p.last_name].filter(Boolean).join(" ").trim();
+  return name || null;
+}
+
+export const GET = (req: NextRequest) =>
+  withAuth(req, async () => {
+    const { canAccessOperationsConsole } = await resolveServerOrgContext();
+    if (!canAccessOperationsConsole) return forbidden("Operations Console access required");
+
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("beta_feedback")
+      .select("id, user_id, type, severity, title, description, status, created_at")
+      .order("created_at", { ascending: false })
+      .limit(200)
+      .returns<FeedbackRow[]>();
+
+    if (error) {
+      console.error("[/api/operations/feedback] supabase error:", error);
+      return ok({ feedback: [] });
+    }
+
+    const rows = data ?? [];
+    const userIds = Array.from(new Set(rows.map((r) => r.user_id).filter((id): id is string => !!id)));
+
+    const profileMap = new Map<string, ProfileRow>();
+    if (userIds.length > 0) {
+      const { data: profiles, error: profErr } = await admin
+        .from("profiles")
+        .select("id, email, first_name, last_name")
+        .in("id", userIds)
+        .returns<ProfileRow[]>();
+      if (profErr) {
+        console.error("[/api/operations/feedback] profile lookup error:", profErr);
+      } else {
+        for (const p of profiles ?? []) profileMap.set(p.id, p);
+      }
+    }
+
+    const feedback = rows.map((row) => {
+      const profile = row.user_id ? profileMap.get(row.user_id) : undefined;
+      return {
+        id: row.id,
+        category: mapTypeToCategory(row.type),
+        type: row.type,
+        title: row.title,
+        description: row.description,
+        severity: row.severity,
+        status: row.status,
+        created_at: row.created_at,
+        user_email: profile?.email ?? null,
+        user_name: fullName(profile),
+      };
+    });
+
+    return ok({ feedback });
+  });

--- a/app/api/operations/organizations/route.ts
+++ b/app/api/operations/organizations/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from "next/server";
+import { withAuth } from "@/lib/server/api-auth";
+import { resolveServerOrgContext } from "@/lib/server/org-context";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { ok, forbidden, serverError } from "@/lib/server/api-response";
+
+export const dynamic = "force-dynamic";
+
+interface OrgRow {
+  id: string;
+  name: string;
+  slug: string | null;
+  tier: string | null;
+  plan_type: string | null;
+  subscription_status: string | null;
+  seats_purchased: number | null;
+  seats_used: number | null;
+  created_at: string;
+  organization_members: Array<{ count: number }> | null;
+}
+
+export const GET = (req: NextRequest) =>
+  withAuth(req, async () => {
+    const { canAccessOperationsConsole } = await resolveServerOrgContext();
+    if (!canAccessOperationsConsole) return forbidden("Operations Console access required");
+
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("organizations")
+      .select(
+        "id, name, slug, tier, plan_type, subscription_status, seats_purchased, seats_used, created_at, organization_members(count)",
+      )
+      .order("created_at", { ascending: false })
+      .limit(500)
+      .returns<OrgRow[]>();
+
+    if (error) {
+      console.error("[/api/operations/organizations] supabase error:", error);
+      return serverError("Failed to load organizations");
+    }
+
+    const organizations = (data ?? []).map((row) => ({
+      id: row.id,
+      name: row.name,
+      slug: row.slug,
+      tier: row.tier,
+      plan_type: row.plan_type,
+      subscription_status: row.subscription_status,
+      seats_purchased: row.seats_purchased,
+      seats_used: row.seats_used,
+      created_at: row.created_at,
+      member_count: row.organization_members?.[0]?.count ?? 0,
+    }));
+
+    return ok({ organizations });
+  });

--- a/app/api/operations/overview/route.ts
+++ b/app/api/operations/overview/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest } from "next/server";
+import { withAuth } from "@/lib/server/api-auth";
+import { resolveServerOrgContext } from "@/lib/server/org-context";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { ok, forbidden, serverError } from "@/lib/server/api-response";
+
+export const dynamic = "force-dynamic";
+
+export const GET = (req: NextRequest) =>
+  withAuth(req, async () => {
+    const { canAccessOperationsConsole } = await resolveServerOrgContext();
+    if (!canAccessOperationsConsole) return forbidden("Operations Console access required");
+
+    const admin = createAdminClient();
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+    const [
+      totalUsersRes,
+      onboardedRes,
+      pendingBetaRes,
+      totalOrgsRes,
+      newUsersRes,
+      newOrgsRes,
+    ] = await Promise.all([
+      admin.from("profiles").select("id", { count: "exact", head: true }),
+      admin
+        .from("profiles")
+        .select("id", { count: "exact", head: true })
+        .not("onboarding_completed_at", "is", null),
+      admin
+        .from("profiles")
+        .select("id", { count: "exact", head: true })
+        .eq("beta_tester", false),
+      admin.from("organizations").select("id", { count: "exact", head: true }),
+      admin
+        .from("profiles")
+        .select("id", { count: "exact", head: true })
+        .gte("created_at", sevenDaysAgo),
+      admin
+        .from("organizations")
+        .select("id", { count: "exact", head: true })
+        .gte("created_at", sevenDaysAgo),
+    ]);
+
+    const firstError =
+      totalUsersRes.error ||
+      onboardedRes.error ||
+      pendingBetaRes.error ||
+      totalOrgsRes.error ||
+      newUsersRes.error ||
+      newOrgsRes.error;
+    if (firstError) {
+      console.error("[/api/operations/overview] supabase error:", firstError);
+      return serverError("Failed to load overview metrics");
+    }
+
+    return ok({
+      metrics: {
+        totalUsers: totalUsersRes.count ?? 0,
+        onboardedUsers: onboardedRes.count ?? 0,
+        pendingBeta: pendingBetaRes.count ?? 0,
+        totalOrgs: totalOrgsRes.count ?? 0,
+        newUsers7d: newUsersRes.count ?? 0,
+        newOrgs7d: newOrgsRes.count ?? 0,
+      },
+    });
+  });

--- a/app/api/operations/plans/route.ts
+++ b/app/api/operations/plans/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest } from "next/server";
+import { withAuth } from "@/lib/server/api-auth";
+import { resolveServerOrgContext } from "@/lib/server/org-context";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { ok, forbidden, serverError } from "@/lib/server/api-response";
+
+export const dynamic = "force-dynamic";
+
+interface PlanEntitlement {
+  id: string;
+  name: string;
+  price: string;
+  interval: string;
+  activeOrgs: number;
+  features: string[];
+  entitlementsJson: string;
+}
+
+const PLAN_DEFS: Omit<PlanEntitlement, "activeOrgs">[] = [
+  {
+    id: "trial",
+    name: "Trial / Beta",
+    price: "$0",
+    interval: "14 days",
+    features: ["1 Active Project", "5 GB Storage", "Site Walk basic capture", "Community support"],
+    entitlementsJson: JSON.stringify(
+      { maxProjects: 1, storageGB: 5, standalone_punchwalk: true },
+      null,
+      2,
+    ),
+  },
+  {
+    id: "creator",
+    name: "Site Walk Standalone",
+    price: "$39",
+    interval: "month",
+    features: ["5 Active Projects", "50 GB Storage", "Full field capture & export", "Email support"],
+    entitlementsJson: JSON.stringify(
+      { maxProjects: 5, storageGB: 50, standalone_punchwalk: true },
+      null,
+      2,
+    ),
+  },
+  {
+    id: "model",
+    name: "Slate360 Pro Bundle",
+    price: "$88",
+    interval: "month",
+    features: [
+      "15 Active Projects",
+      "250 GB Storage",
+      "360 Tour Builder included",
+      "Priority support",
+    ],
+    entitlementsJson: JSON.stringify(
+      {
+        maxProjects: 15,
+        storageGB: 250,
+        standalone_punchwalk: true,
+        standalone_tour_builder: true,
+      },
+      null,
+      2,
+    ),
+  },
+  {
+    id: "business",
+    name: "Business",
+    price: "$249",
+    interval: "month",
+    features: ["Unlimited Projects", "1 TB Storage", "All standalone apps", "Dedicated support"],
+    entitlementsJson: JSON.stringify(
+      {
+        maxProjects: -1,
+        storageGB: 1024,
+        standalone_punchwalk: true,
+        standalone_tour_builder: true,
+        standalone_design_studio: true,
+        standalone_content_studio: true,
+      },
+      null,
+      2,
+    ),
+  },
+  {
+    id: "enterprise",
+    name: "Enterprise",
+    price: "Custom",
+    interval: "year",
+    features: ["Custom seats", "Custom storage", "SSO + audit log", "White-glove onboarding"],
+    entitlementsJson: JSON.stringify(
+      {
+        maxProjects: -1,
+        storageGB: -1,
+        standalone_punchwalk: true,
+        standalone_tour_builder: true,
+        standalone_design_studio: true,
+        standalone_content_studio: true,
+        sso: true,
+      },
+      null,
+      2,
+    ),
+  },
+];
+
+interface OrgTierRow {
+  tier: string | null;
+}
+
+export const GET = (req: NextRequest) =>
+  withAuth(req, async () => {
+    const { canAccessOperationsConsole } = await resolveServerOrgContext();
+    if (!canAccessOperationsConsole) return forbidden("Operations Console access required");
+
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("organizations")
+      .select("tier")
+      .returns<OrgTierRow[]>();
+
+    if (error) {
+      console.error("[/api/operations/plans] supabase error:", error);
+      return serverError("Failed to load plan counts");
+    }
+
+    const counts = new Map<string, number>();
+    for (const row of data ?? []) {
+      const tier = (row.tier ?? "trial").toLowerCase();
+      counts.set(tier, (counts.get(tier) ?? 0) + 1);
+    }
+
+    const plans: PlanEntitlement[] = PLAN_DEFS.map((p) => ({
+      ...p,
+      activeOrgs: counts.get(p.id) ?? 0,
+    }));
+
+    return ok({ plans });
+  });

--- a/app/api/operations/subscriptions/route.ts
+++ b/app/api/operations/subscriptions/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest } from "next/server";
+import { withAuth } from "@/lib/server/api-auth";
+import { resolveServerOrgContext } from "@/lib/server/org-context";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { ok, forbidden, serverError } from "@/lib/server/api-response";
+
+export const dynamic = "force-dynamic";
+
+type SubStatus = "active" | "trialing" | "past_due" | "canceled";
+
+interface OrgSubRow {
+  id: string;
+  name: string;
+  tier: string | null;
+  subscription_status: string | null;
+  trial_ends_at: string | null;
+  created_at: string;
+}
+
+function projectStatus(row: OrgSubRow): SubStatus {
+  const raw = (row.subscription_status ?? "").toLowerCase();
+  if (raw === "active" || raw === "trialing" || raw === "past_due" || raw === "canceled") {
+    return raw;
+  }
+  const tier = (row.tier ?? "trial").toLowerCase();
+  if (tier === "trial" || tier === "free") return "trialing";
+  return "active";
+}
+
+function projectPeriodEnd(row: OrgSubRow): string {
+  if (row.trial_ends_at) return row.trial_ends_at;
+  const start = new Date(row.created_at);
+  start.setMonth(start.getMonth() + 1);
+  return start.toISOString();
+}
+
+export const GET = (req: NextRequest) =>
+  withAuth(req, async () => {
+    const { canAccessOperationsConsole } = await resolveServerOrgContext();
+    if (!canAccessOperationsConsole) return forbidden("Operations Console access required");
+
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("organizations")
+      .select("id, name, tier, subscription_status, trial_ends_at, created_at")
+      .order("created_at", { ascending: false })
+      .limit(200)
+      .returns<OrgSubRow[]>();
+
+    if (error) {
+      console.error("[/api/operations/subscriptions] supabase error:", error);
+      return serverError("Failed to load subscriptions");
+    }
+
+    const subscriptions = (data ?? []).map((row) => ({
+      org_id: row.id,
+      org_name: row.name,
+      tier: row.tier ?? "trial",
+      status: projectStatus(row),
+      current_period_end: projectPeriodEnd(row),
+    }));
+
+    return ok({ subscriptions });
+  });

--- a/app/api/operations/usage/route.ts
+++ b/app/api/operations/usage/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest } from "next/server";
+import { withAuth } from "@/lib/server/api-auth";
+import { resolveServerOrgContext } from "@/lib/server/org-context";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { ok, forbidden } from "@/lib/server/api-response";
+
+export const dynamic = "force-dynamic";
+
+interface UsageRow {
+  org_id: string;
+  org_name: string | null;
+  storage_used_bytes: number | string | null;
+  storage_limit_bytes: number | string | null;
+  storage_percent_used: number | string | null;
+  total_processing_jobs: number | string | null;
+  projects_count: number | string | null;
+}
+
+function num(v: number | string | null | undefined): number {
+  if (v === null || v === undefined) return 0;
+  if (typeof v === "number") return v;
+  const parsed = Number(v);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export const GET = (req: NextRequest) =>
+  withAuth(req, async () => {
+    const { canAccessOperationsConsole } = await resolveServerOrgContext();
+    if (!canAccessOperationsConsole) return forbidden("Operations Console access required");
+
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("org_usage_summary")
+      .select(
+        "org_id, org_name, storage_used_bytes, storage_limit_bytes, storage_percent_used, total_processing_jobs, projects_count",
+      )
+      .order("storage_used_bytes", { ascending: false })
+      .limit(50)
+      .returns<UsageRow[]>();
+
+    // Graceful fallback if view is missing or empty
+    if (error) {
+      console.error("[/api/operations/usage] supabase error:", error);
+      return ok({ usage: [] });
+    }
+
+    const usage = (data ?? []).map((row) => ({
+      org_id: row.org_id,
+      org_name: row.org_name ?? "Unknown Org",
+      storage_bytes: num(row.storage_used_bytes),
+      storage_limit_bytes: num(row.storage_limit_bytes),
+      storage_percent: num(row.storage_percent_used),
+      processing_jobs: num(row.total_processing_jobs),
+      projects_count: num(row.projects_count),
+    }));
+
+    return ok({ usage });
+  });

--- a/app/api/operations/users/route.ts
+++ b/app/api/operations/users/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest } from "next/server";
+import { withAuth } from "@/lib/server/api-auth";
+import { resolveServerOrgContext } from "@/lib/server/org-context";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { ok, forbidden, serverError } from "@/lib/server/api-response";
+
+export const dynamic = "force-dynamic";
+
+export const GET = (req: NextRequest) =>
+  withAuth(req, async () => {
+    const { canAccessOperationsConsole } = await resolveServerOrgContext();
+    if (!canAccessOperationsConsole) return forbidden("Operations Console access required");
+
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("profiles")
+      .select(
+        "id, email, first_name, last_name, organization_name, role, beta_tester, onboarding_completed_at, created_at",
+      )
+      .order("created_at", { ascending: false })
+      .limit(1000);
+
+    if (error) {
+      console.error("[/api/operations/users] supabase error:", error);
+      return serverError("Failed to load user accounts");
+    }
+
+    return ok({ users: data ?? [] });
+  });

--- a/components/dashboard/operations/BetaApprovalsTab.tsx
+++ b/components/dashboard/operations/BetaApprovalsTab.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, CheckCircle2, XCircle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { FloatingToast } from "@/components/shared/FloatingToast";
+import { useBetaUsers } from "@/lib/hooks/useBetaUsers";
+import type { BetaUser } from "@/lib/hooks/useBetaUsers";
+
+export function BetaApprovalsTab() {
+  const { users, loading, error, reload, toggleApproval } = useBetaUsers();
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+  const [toast, setToast] = useState<{ message: string; variant: "success" | "error" } | null>(null);
+  const [filter, setFilter] = useState<"all" | "approved" | "pending">("all");
+
+  const filtered = users.filter((u) => {
+    if (filter === "approved") return u.is_beta_approved;
+    if (filter === "pending") return !u.is_beta_approved;
+    return true;
+  });
+
+  const approvedCount = users.filter((u) => u.is_beta_approved).length;
+  const pendingCount = users.filter((u) => !u.is_beta_approved).length;
+
+  async function handleToggle(user: BetaUser) {
+    setTogglingId(user.id);
+    try {
+      await toggleApproval(user.id, !user.is_beta_approved);
+      setToast({
+        message: `${user.email ?? user.id.slice(0, 8)} ${!user.is_beta_approved ? "approved" : "revoked"}`,
+        variant: "success",
+      });
+    } catch (err) {
+      setToast({
+        message: err instanceof Error ? err.message : "Failed to update",
+        variant: "error",
+      });
+    } finally {
+      setTogglingId(null);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {toast && (
+        <FloatingToast
+          message={toast.message}
+          variant={toast.variant}
+          duration={4000}
+          onDismiss={() => setToast(null)}
+        />
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <SummaryCard label="Total Users" value={users.length} loading={loading} />
+        <SummaryCard label="Beta Approved" value={approvedCount} loading={loading} accent="text-green-500" />
+        <SummaryCard label="Pending" value={pendingCount} loading={loading} accent="text-amber-500" />
+      </div>
+
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-1 rounded-lg border border-border bg-card p-1">
+          {(["all", "approved", "pending"] as const).map((f) => (
+            <button
+              key={f}
+              onClick={() => setFilter(f)}
+              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors whitespace-nowrap ${
+                filter === f
+                  ? "bg-cobalt text-white shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {f === "all"
+                ? `All (${users.length})`
+                : f === "approved"
+                ? `Approved (${approvedCount})`
+                : `Pending (${pendingCount})`}
+            </button>
+          ))}
+        </div>
+        <Button variant="ghost" size="sm" onClick={reload} disabled={loading}>
+          <RefreshCw className={`mr-1 h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {loading && users.length === 0 ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-red-800 bg-red-950/30 p-4 text-sm text-red-300">
+          {error}
+          <Button variant="outline" size="sm" className="ml-3" onClick={reload}>
+            Retry
+          </Button>
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="py-12 text-center text-sm text-muted-foreground">No users match this filter.</div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-border bg-card">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="border-b border-border bg-muted/30">
+                <tr>
+                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">User</th>
+                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Company</th>
+                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Joined</th>
+                  <th className="px-4 py-2.5 text-center text-xs font-medium text-muted-foreground">Beta Status</th>
+                  <th className="px-4 py-2.5 text-right text-xs font-medium text-muted-foreground">Action</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {filtered.map((u) => (
+                  <UserRow
+                    key={u.id}
+                    user={u}
+                    toggling={togglingId === u.id}
+                    onToggle={() => handleToggle(u)}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SummaryCard({
+  label,
+  value,
+  loading,
+  accent,
+}: {
+  label: string;
+  value: number;
+  loading: boolean;
+  accent?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      {loading ? (
+        <Loader2 className="mt-1 h-5 w-5 animate-spin text-muted-foreground" />
+      ) : (
+        <p className={`mt-1 text-2xl font-bold ${accent ?? "text-foreground"}`}>{value}</p>
+      )}
+    </div>
+  );
+}
+
+function UserRow({
+  user,
+  toggling,
+  onToggle,
+}: {
+  user: BetaUser;
+  toggling: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <tr className="hover:bg-muted/20">
+      <td className="px-4 py-3">
+        <div>
+          <p className="font-medium text-foreground">
+            {user.display_name || user.email || user.id.slice(0, 8)}
+          </p>
+          {user.email && user.display_name && (
+            <p className="text-xs text-muted-foreground">{user.email}</p>
+          )}
+        </div>
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">{user.company || "—"}</td>
+      <td className="px-4 py-3 text-muted-foreground">
+        {new Date(user.created_at).toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+        })}
+      </td>
+      <td className="px-4 py-3 text-center">
+        {user.is_beta_approved ? (
+          <span className="inline-flex items-center gap-1 rounded-full bg-green-900/30 px-2 py-0.5 text-xs font-medium text-green-300">
+            <CheckCircle2 className="h-3 w-3" /> Approved
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1 rounded-full bg-amber-900/30 px-2 py-0.5 text-xs font-medium text-amber-300">
+            <XCircle className="h-3 w-3" /> Pending
+          </span>
+        )}
+      </td>
+      <td className="px-4 py-3 text-right">
+        <Button
+          variant={user.is_beta_approved ? "outline" : "default"}
+          size="sm"
+          disabled={toggling}
+          onClick={onToggle}
+          className="min-w-[80px]"
+        >
+          {toggling ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : user.is_beta_approved ? (
+            "Revoke"
+          ) : (
+            "Approve"
+          )}
+        </Button>
+      </td>
+    </tr>
+  );
+}

--- a/components/dashboard/operations/CommunicationsFeedbackTab.tsx
+++ b/components/dashboard/operations/CommunicationsFeedbackTab.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2, Bug, Lightbulb, MessageSquare, ChevronDown, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type FeedbackStatus = "new" | "triaged" | "in_progress" | "resolved" | "wont_fix" | "duplicate";
+type FeedbackCategory = "bug" | "suggestion" | "other";
+
+interface FeedbackItem {
+  id: string;
+  category: FeedbackCategory;
+  type: string;
+  title: string;
+  description: string;
+  severity: string | null;
+  status: FeedbackStatus;
+  created_at: string;
+  user_email: string | null;
+  user_name: string | null;
+}
+
+const STATUS_OPTIONS: { value: FeedbackStatus; label: string }[] = [
+  { value: "new", label: "New" },
+  { value: "triaged", label: "Triaged" },
+  { value: "in_progress", label: "In Progress" },
+  { value: "resolved", label: "Resolved" },
+  { value: "wont_fix", label: "Won't Fix" },
+  { value: "duplicate", label: "Duplicate" },
+];
+
+export function CommunicationsFeedbackTab() {
+  const [items, setItems] = useState<FeedbackItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [statusLoading, setStatusLoading] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    const res = await fetch("/api/operations/feedback");
+    if (!res.ok) {
+      setError("Failed to load feedback");
+      setLoading(false);
+      return;
+    }
+    const data = (await res.json()) as { feedback?: FeedbackItem[] };
+    setItems(data.feedback ?? []);
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function updateStatus(id: string, newStatus: FeedbackStatus) {
+    setStatusLoading(id);
+    const res = await fetch(`/api/operations/feedback/${id}/status`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: newStatus }),
+    });
+    if (res.ok) {
+      setItems((prev) =>
+        prev.map((it) => (it.id === id ? { ...it, status: newStatus } : it)),
+      );
+    }
+    setStatusLoading(null);
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center p-12">
+        <Loader2 className="w-8 h-8 animate-spin text-cobalt" />
+      </div>
+    );
+  }
+  if (error) return <p className="p-6 text-sm text-red-500">{error}</p>;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-muted-foreground">{items.length} item(s)</p>
+        <Button variant="ghost" size="sm" onClick={load}>
+          <RefreshCw className="mr-1 h-3.5 w-3.5" />
+          Refresh
+        </Button>
+      </div>
+
+      <div className="bg-card border border-border rounded-xl overflow-hidden">
+        <div className="divide-y divide-border">
+          {items.map((item) => (
+            <FeedbackRow
+              key={item.id}
+              item={item}
+              expanded={expandedId === item.id}
+              onToggle={() => setExpandedId(expandedId === item.id ? null : item.id)}
+              onStatusChange={(s) => updateStatus(item.id, s)}
+              statusUpdating={statusLoading === item.id}
+            />
+          ))}
+          {items.length === 0 && (
+            <div className="p-8 text-center text-muted-foreground">No feedback items found.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FeedbackRow({
+  item,
+  expanded,
+  onToggle,
+  onStatusChange,
+  statusUpdating,
+}: {
+  item: FeedbackItem;
+  expanded: boolean;
+  onToggle: () => void;
+  onStatusChange: (s: FeedbackStatus) => void;
+  statusUpdating: boolean;
+}) {
+  const Icon =
+    item.category === "bug" ? Bug : item.category === "suggestion" ? Lightbulb : MessageSquare;
+  const iconColor =
+    item.category === "bug"
+      ? "text-red-500"
+      : item.category === "suggestion"
+      ? "text-yellow-500"
+      : "text-cobalt";
+
+  return (
+    <div className="flex flex-col">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex items-center justify-between p-4 hover:bg-muted/20 transition-colors text-left w-full"
+      >
+        <div className="flex items-center gap-4 flex-1 min-w-0">
+          <div className="w-8 h-8 rounded-full bg-background border border-border flex items-center justify-center shrink-0">
+            <Icon className={`w-4 h-4 ${iconColor}`} />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h4 className="text-sm font-semibold text-foreground truncate">{item.title}</h4>
+            <p className="text-xs text-muted-foreground truncate">
+              {item.user_name || item.user_email || "Unknown user"} ·{" "}
+              {new Date(item.created_at).toLocaleDateString()}
+            </p>
+          </div>
+          {item.severity && (
+            <span className="hidden sm:inline-flex px-2 py-1 text-[10px] font-bold uppercase bg-muted/30 border border-border rounded text-muted-foreground">
+              {item.severity}
+            </span>
+          )}
+          <StatusPill status={item.status} />
+          <ChevronDown
+            className={`w-4 h-4 text-muted-foreground transition-transform ${
+              expanded ? "rotate-180" : ""
+            }`}
+          />
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="p-4 bg-background border-t border-border flex flex-col gap-4">
+          <div className="text-sm text-foreground whitespace-pre-wrap bg-card border border-border p-4 rounded-lg">
+            {item.description}
+          </div>
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <div className="text-xs text-muted-foreground">
+              Type: <span className="text-foreground">{item.type}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted-foreground">Status:</span>
+              <select
+                value={item.status}
+                onChange={(e) => onStatusChange(e.target.value as FeedbackStatus)}
+                disabled={statusUpdating}
+                className="bg-card border border-border text-sm text-foreground rounded-md px-3 py-1.5 outline-none focus:border-cobalt disabled:opacity-50"
+              >
+                {STATUS_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+              {statusUpdating && <Loader2 className="w-4 h-4 animate-spin text-cobalt" />}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusPill({ status }: { status: FeedbackStatus }) {
+  const className =
+    status === "new"
+      ? "bg-cobalt/10 text-cobalt"
+      : status === "resolved"
+      ? "bg-green-500/15 text-green-500"
+      : status === "in_progress" || status === "triaged"
+      ? "bg-yellow-500/10 text-yellow-500"
+      : "bg-muted/30 text-muted-foreground";
+  return (
+    <span className={`text-xs font-medium px-2.5 py-1 rounded-full whitespace-nowrap ${className}`}>
+      {status.replace("_", " ")}
+    </span>
+  );
+}

--- a/components/dashboard/operations/OperationsConsoleClient.tsx
+++ b/components/dashboard/operations/OperationsConsoleClient.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+import {
+  LayoutDashboard,
+  Shield,
+  Users,
+  Building2,
+  Tag,
+  CreditCard,
+  DollarSign,
+  Activity,
+  FolderOpen,
+  Mail,
+  LifeBuoy,
+  ClipboardList,
+  Briefcase,
+  Settings,
+  FileText,
+} from "lucide-react";
+import { OverviewTab } from "./OverviewTab";
+import { BetaApprovalsTab } from "./BetaApprovalsTab";
+import { UserAccountsTab } from "./UserAccountsTab";
+import { OrganizationsTab } from "./OrganizationsTab";
+
+type TabID =
+  | "overview"
+  | "beta"
+  | "users"
+  | "orgs"
+  | "plans"
+  | "subs"
+  | "revenue"
+  | "usage"
+  | "content"
+  | "comms"
+  | "support"
+  | "surveys"
+  | "employees"
+  | "product_ops"
+  | "audit";
+
+interface TabDef {
+  id: TabID;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
+
+const TABS: TabDef[] = [
+  { id: "overview", label: "Overview", icon: LayoutDashboard },
+  { id: "beta", label: "Beta Approvals", icon: Shield },
+  { id: "users", label: "User Accounts", icon: Users },
+  { id: "orgs", label: "Organizations", icon: Building2 },
+  { id: "plans", label: "Plans & Pricing", icon: Tag },
+  { id: "subs", label: "Subscriptions", icon: CreditCard },
+  { id: "revenue", label: "Revenue", icon: DollarSign },
+  { id: "usage", label: "Usage", icon: Activity },
+  { id: "content", label: "Content Assets", icon: FolderOpen },
+  { id: "comms", label: "Communications", icon: Mail },
+  { id: "support", label: "Support", icon: LifeBuoy },
+  { id: "surveys", label: "Surveys", icon: ClipboardList },
+  { id: "employees", label: "Employees", icon: Briefcase },
+  { id: "product_ops", label: "Product Ops", icon: Settings },
+  { id: "audit", label: "Audit Log", icon: FileText },
+];
+
+const PHASE_2_TABS: ReadonlyArray<TabID> = [
+  "plans",
+  "subs",
+  "revenue",
+  "usage",
+  "content",
+  "comms",
+  "support",
+  "surveys",
+  "employees",
+  "product_ops",
+  "audit",
+];
+
+type Props = {
+  ownerEmail: string;
+};
+
+export function OperationsConsoleClient({ ownerEmail }: Props) {
+  const [activeTab, setActiveTab] = useState<TabID>("overview");
+  const activeDef = TABS.find((t) => t.id === activeTab) ?? TABS[0];
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 py-6 space-y-6">
+        <div className="flex items-center gap-3">
+          <div className="rounded-lg bg-cobalt/10 p-2">
+            <Shield className="h-5 w-5 text-cobalt" />
+          </div>
+          <div>
+            <h1 className="text-xl font-bold text-foreground">Operations Console</h1>
+            <p className="text-xs text-muted-foreground">Slate360 platform admin · {ownerEmail}</p>
+          </div>
+        </div>
+
+        <div className="border-b border-border">
+          <div className="overflow-x-auto -mb-px">
+            <div className="flex gap-1 min-w-max">
+              {TABS.map((tab) => {
+                const Icon = tab.icon;
+                const active = tab.id === activeTab;
+                return (
+                  <button
+                    key={tab.id}
+                    onClick={() => setActiveTab(tab.id)}
+                    className={`whitespace-nowrap inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+                      active
+                        ? "border-cobalt text-cobalt"
+                        : "border-transparent text-muted-foreground hover:text-foreground hover:border-border"
+                    }`}
+                  >
+                    <Icon className="h-4 w-4" />
+                    {tab.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        <div>
+          {activeTab === "overview" && <OverviewTab />}
+          {activeTab === "beta" && <BetaApprovalsTab />}
+          {activeTab === "users" && <UserAccountsTab />}
+          {activeTab === "orgs" && <OrganizationsTab />}
+          {PHASE_2_TABS.includes(activeTab) && <Phase2Placeholder label={activeDef.label} />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default OperationsConsoleClient;
+
+function Phase2Placeholder({ label }: { label: string }) {
+  return (
+    <div className="rounded-xl border border-dashed border-border bg-card p-10 text-center">
+      <h3 className="text-base font-semibold text-foreground mb-1">{label}</h3>
+      <p className="text-sm text-muted-foreground">
+        Module under construction — coming in Operations Console Phase 2.
+      </p>
+    </div>
+  );
+}

--- a/components/dashboard/operations/OperationsConsoleClient.tsx
+++ b/components/dashboard/operations/OperationsConsoleClient.tsx
@@ -22,6 +22,10 @@ import { OverviewTab } from "./OverviewTab";
 import { BetaApprovalsTab } from "./BetaApprovalsTab";
 import { UserAccountsTab } from "./UserAccountsTab";
 import { OrganizationsTab } from "./OrganizationsTab";
+import { PlansPricingTab } from "./PlansPricingTab";
+import { SubscriptionsTab } from "./SubscriptionsTab";
+import { UsageProcessingTab } from "./UsageProcessingTab";
+import { CommunicationsFeedbackTab } from "./CommunicationsFeedbackTab";
 
 type TabID =
   | "overview"
@@ -65,12 +69,8 @@ const TABS: TabDef[] = [
 ];
 
 const PHASE_2_TABS: ReadonlyArray<TabID> = [
-  "plans",
-  "subs",
   "revenue",
-  "usage",
   "content",
-  "comms",
   "support",
   "surveys",
   "employees",
@@ -129,6 +129,10 @@ export function OperationsConsoleClient({ ownerEmail }: Props) {
           {activeTab === "beta" && <BetaApprovalsTab />}
           {activeTab === "users" && <UserAccountsTab />}
           {activeTab === "orgs" && <OrganizationsTab />}
+          {activeTab === "plans" && <PlansPricingTab />}
+          {activeTab === "subs" && <SubscriptionsTab />}
+          {activeTab === "usage" && <UsageProcessingTab />}
+          {activeTab === "comms" && <CommunicationsFeedbackTab />}
           {PHASE_2_TABS.includes(activeTab) && <Phase2Placeholder label={activeDef.label} />}
         </div>
       </div>

--- a/components/dashboard/operations/OrganizationsTab.tsx
+++ b/components/dashboard/operations/OrganizationsTab.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2, Building2, Users as UsersIcon, RefreshCw, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface Organization {
+  id: string;
+  name: string;
+  slug: string | null;
+  tier: string | null;
+  plan_type: string | null;
+  subscription_status: string | null;
+  seats_purchased: number | null;
+  seats_used: number | null;
+  member_count: number;
+  created_at: string;
+}
+
+export function OrganizationsTab() {
+  const [orgs, setOrgs] = useState<Organization[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    const res = await fetch("/api/operations/organizations");
+    if (!res.ok) {
+      setError("Failed to load organizations");
+      setLoading(false);
+      return;
+    }
+    const data = (await res.json()) as { organizations?: Organization[] };
+    setOrgs(data.organizations ?? []);
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const filtered = orgs.filter((o) => {
+    if (!search.trim()) return true;
+    const q = search.toLowerCase();
+    return (
+      o.name.toLowerCase().includes(q) ||
+      (o.slug ?? "").toLowerCase().includes(q) ||
+      (o.tier ?? "").toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3 flex-wrap">
+        <div className="relative flex-1 min-w-[240px]">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by name, slug, or tier…"
+            className="w-full bg-card border border-border rounded-lg pl-10 pr-4 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-cobalt/40"
+          />
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {filtered.length} of {orgs.length}
+        </div>
+        <Button variant="ghost" size="sm" onClick={load} disabled={loading}>
+          <RefreshCw className={`mr-1 h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {loading && orgs.length === 0 ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-red-800 bg-red-950/30 p-4 text-sm text-red-300">
+          {error}
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="py-12 text-center text-sm text-muted-foreground">
+          No organizations match this search.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filtered.map((org) => (
+            <div
+              key={org.id}
+              className="bg-card border border-border rounded-xl p-5 hover:border-cobalt/40 transition-colors"
+            >
+              <div className="flex items-start justify-between mb-3">
+                <div className="flex items-center gap-2 min-w-0">
+                  <Building2 className="h-4 w-4 text-cobalt flex-shrink-0" />
+                  <h3 className="text-sm font-semibold text-foreground truncate">{org.name}</h3>
+                </div>
+                {org.tier && (
+                  <span className="inline-flex items-center rounded-full bg-cobalt/15 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-cobalt">
+                    {org.tier}
+                  </span>
+                )}
+              </div>
+
+              <dl className="space-y-1.5 text-xs">
+                <div className="flex justify-between">
+                  <dt className="text-muted-foreground">Members</dt>
+                  <dd className="text-foreground inline-flex items-center gap-1">
+                    <UsersIcon className="h-3 w-3" />
+                    {org.member_count}
+                    {org.seats_purchased ? (
+                      <span className="text-muted-foreground">/ {org.seats_purchased}</span>
+                    ) : null}
+                  </dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-muted-foreground">Plan</dt>
+                  <dd className="text-foreground">{org.plan_type ?? "—"}</dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-muted-foreground">Status</dt>
+                  <dd className="text-foreground">{org.subscription_status ?? "—"}</dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-muted-foreground">Created</dt>
+                  <dd className="text-foreground">
+                    {new Date(org.created_at).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    })}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/dashboard/operations/OverviewTab.tsx
+++ b/components/dashboard/operations/OverviewTab.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2, Users, Building2, Shield, Clock } from "lucide-react";
+
+interface OverviewMetrics {
+  totalUsers: number;
+  onboardedUsers: number;
+  pendingBeta: number;
+  totalOrgs: number;
+  newUsers7d: number;
+  newOrgs7d: number;
+}
+
+const EMPTY_METRICS: OverviewMetrics = {
+  totalUsers: 0,
+  onboardedUsers: 0,
+  pendingBeta: 0,
+  totalOrgs: 0,
+  newUsers7d: 0,
+  newOrgs7d: 0,
+};
+
+export function OverviewTab() {
+  const [metrics, setMetrics] = useState<OverviewMetrics>(EMPTY_METRICS);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      const res = await fetch("/api/operations/overview");
+      if (cancelled) return;
+      if (!res.ok) {
+        setError("Failed to load overview metrics");
+        setLoading(false);
+        return;
+      }
+      const data = (await res.json()) as { metrics?: OverviewMetrics };
+      setMetrics(data.metrics ?? EMPTY_METRICS);
+      setLoading(false);
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center p-12">
+        <Loader2 className="w-8 h-8 animate-spin text-cobalt" />
+      </div>
+    );
+  }
+  if (error) {
+    return <p className="p-6 text-sm text-red-500">{error}</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <MetricCard label="Total users" value={metrics.totalUsers} icon={<Users className="w-5 h-5" />} />
+        <MetricCard
+          label="Onboarded"
+          value={metrics.onboardedUsers}
+          icon={<Shield className="w-5 h-5" />}
+          accent="text-teal"
+        />
+        <MetricCard
+          label="Pending beta"
+          value={metrics.pendingBeta}
+          icon={<Clock className="w-5 h-5" />}
+          accent="text-yellow-500"
+        />
+        <MetricCard label="Organizations" value={metrics.totalOrgs} icon={<Building2 className="w-5 h-5" />} />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <MetricCard label="New users (7d)" value={metrics.newUsers7d} icon={<Users className="w-5 h-5" />} />
+        <MetricCard label="New orgs (7d)" value={metrics.newOrgs7d} icon={<Building2 className="w-5 h-5" />} />
+      </div>
+
+      <div className="bg-card border border-border rounded-xl p-5">
+        <h3 className="text-sm font-semibold text-foreground mb-2">What&apos;s in Phase 1</h3>
+        <ul className="text-sm text-muted-foreground space-y-1.5 list-disc pl-5">
+          <li>Beta Approvals — approve/revoke beta access</li>
+          <li>User Accounts — search every account, see onboarding + beta status</li>
+          <li>Organizations — list orgs with member counts and tier</li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function MetricCard({
+  label,
+  value,
+  icon,
+  accent,
+}: {
+  label: string;
+  value: number;
+  icon: React.ReactNode;
+  accent?: string;
+}) {
+  return (
+    <div className="bg-card border border-border rounded-xl p-5">
+      <div className="flex items-center justify-between mb-3 text-muted-foreground">
+        <span className="text-xs uppercase tracking-wider">{label}</span>
+        <span className={accent ?? "text-cobalt"}>{icon}</span>
+      </div>
+      <div className={`text-3xl font-bold ${accent ?? "text-foreground"}`}>{value.toLocaleString()}</div>
+    </div>
+  );
+}

--- a/components/dashboard/operations/PlansPricingTab.tsx
+++ b/components/dashboard/operations/PlansPricingTab.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2, Package, Check } from "lucide-react";
+
+interface PlanEntitlement {
+  id: string;
+  name: string;
+  price: string;
+  interval: string;
+  activeOrgs: number;
+  features: string[];
+  entitlementsJson: string;
+}
+
+export function PlansPricingTab() {
+  const [plans, setPlans] = useState<PlanEntitlement[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      const res = await fetch("/api/operations/plans");
+      if (cancelled) return;
+      if (!res.ok) {
+        setError("Failed to load plans");
+        setLoading(false);
+        return;
+      }
+      const data = (await res.json()) as { plans?: PlanEntitlement[] };
+      setPlans(data.plans ?? []);
+      setLoading(false);
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center p-12">
+        <Loader2 className="w-8 h-8 animate-spin text-cobalt" />
+      </div>
+    );
+  }
+  if (error) return <p className="p-6 text-sm text-red-500">{error}</p>;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h2 className="text-lg font-semibold text-foreground">Active Plans &amp; Entitlements</h2>
+        <button
+          disabled
+          className="bg-cobalt/60 text-white px-4 py-2 rounded-lg text-sm font-medium cursor-not-allowed"
+          title="Phase 2"
+        >
+          Simulate Pricing
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {plans.map((plan) => (
+          <div
+            key={plan.id}
+            className="bg-card border border-border rounded-xl p-6 flex flex-col hover:border-cobalt transition-colors"
+          >
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 bg-muted/30 rounded-lg flex items-center justify-center text-muted-foreground">
+                <Package className="w-5 h-5" />
+              </div>
+              <div>
+                <h3 className="font-semibold text-foreground">{plan.name}</h3>
+                <div className="text-sm font-bold text-cobalt">
+                  {plan.price}{" "}
+                  <span className="text-xs text-muted-foreground font-normal">/{plan.interval}</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="text-xs text-muted-foreground mb-4 bg-muted/20 p-2 rounded border border-border flex items-center justify-between">
+              <span>Active Subscriptions</span>
+              <span className="font-bold text-foreground">{plan.activeOrgs}</span>
+            </div>
+
+            <div className="flex-1 space-y-2 mb-6">
+              {plan.features.map((feat) => (
+                <div key={feat} className="flex items-start gap-2 text-sm text-foreground">
+                  <Check className="w-4 h-4 text-green-500 shrink-0 mt-0.5" />
+                  <span>{feat}</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-auto">
+              <p className="text-xs text-muted-foreground mb-2 font-medium">Entitlements JSON</p>
+              <pre className="bg-background border border-border rounded-lg p-3 text-[10px] text-muted-foreground overflow-x-auto">
+                {plan.entitlementsJson}
+              </pre>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/operations/SubscriptionsTab.tsx
+++ b/components/dashboard/operations/SubscriptionsTab.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2, CreditCard, AlertTriangle, CheckCircle2 } from "lucide-react";
+
+type SubStatus = "active" | "trialing" | "past_due" | "canceled";
+
+interface SubRow {
+  org_id: string;
+  org_name: string;
+  tier: string;
+  status: SubStatus;
+  current_period_end: string;
+}
+
+export function SubscriptionsTab() {
+  const [subs, setSubs] = useState<SubRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      const res = await fetch("/api/operations/subscriptions");
+      if (cancelled) return;
+      if (!res.ok) {
+        setError("Failed to load subscriptions");
+        setLoading(false);
+        return;
+      }
+      const data = (await res.json()) as { subscriptions?: SubRow[] };
+      setSubs(data.subscriptions ?? []);
+      setLoading(false);
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center p-12">
+        <Loader2 className="w-8 h-8 animate-spin text-cobalt" />
+      </div>
+    );
+  }
+  if (error) return <p className="p-6 text-sm text-red-500">{error}</p>;
+
+  return (
+    <div className="bg-card border border-border rounded-xl overflow-hidden">
+      <div className="p-4 border-b border-border bg-muted/30 flex justify-between items-center">
+        <h2 className="text-sm font-semibold text-foreground">Organization Subscriptions</h2>
+        <button
+          disabled
+          className="text-xs bg-muted/30 border border-border px-3 py-1.5 rounded-md text-muted-foreground cursor-not-allowed"
+          title="Phase 2 — Stripe sync"
+        >
+          Sync with Stripe
+        </button>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-muted/20 border-b border-border text-muted-foreground">
+            <tr>
+              <th className="px-6 py-3 font-medium">Organization</th>
+              <th className="px-6 py-3 font-medium">Tier</th>
+              <th className="px-6 py-3 font-medium">Status</th>
+              <th className="px-6 py-3 font-medium">Renews / Expires</th>
+              <th className="px-6 py-3 font-medium text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {subs.map((sub) => (
+              <tr key={sub.org_id} className="hover:bg-muted/20 transition-colors">
+                <td className="px-6 py-4 font-medium text-foreground">{sub.org_name}</td>
+                <td className="px-6 py-4 text-foreground uppercase tracking-wider text-xs font-bold">
+                  {sub.tier}
+                </td>
+                <td className="px-6 py-4">
+                  <StatusBadge status={sub.status} />
+                </td>
+                <td className="px-6 py-4 text-muted-foreground text-xs">
+                  {new Date(sub.current_period_end).toLocaleDateString()}
+                </td>
+                <td className="px-6 py-4 text-right">
+                  <button disabled className="text-xs text-cobalt/60 font-medium cursor-not-allowed">
+                    Manage
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {subs.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-6 py-8 text-center text-muted-foreground">
+                  No subscriptions found.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: SubStatus }) {
+  if (status === "active")
+    return (
+      <span className="inline-flex items-center gap-1 text-green-500 text-xs font-medium">
+        <CheckCircle2 className="w-3.5 h-3.5" /> Active
+      </span>
+    );
+  if (status === "trialing")
+    return (
+      <span className="inline-flex items-center gap-1 text-cobalt text-xs font-medium">
+        <CreditCard className="w-3.5 h-3.5" /> Trial
+      </span>
+    );
+  if (status === "past_due")
+    return (
+      <span className="inline-flex items-center gap-1 text-yellow-500 text-xs font-medium">
+        <AlertTriangle className="w-3.5 h-3.5" /> Past Due
+      </span>
+    );
+  return (
+    <span className="inline-flex items-center gap-1 text-red-500 text-xs font-medium">
+      <AlertTriangle className="w-3.5 h-3.5" /> Canceled
+    </span>
+  );
+}

--- a/components/dashboard/operations/UsageProcessingTab.tsx
+++ b/components/dashboard/operations/UsageProcessingTab.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2, HardDrive, Cpu, Image as ImageIcon } from "lucide-react";
+
+interface UsageData {
+  org_id: string;
+  org_name: string;
+  storage_bytes: number;
+  storage_limit_bytes: number;
+  storage_percent: number;
+  processing_jobs: number;
+  projects_count: number;
+}
+
+export function UsageProcessingTab() {
+  const [usage, setUsage] = useState<UsageData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      const res = await fetch("/api/operations/usage");
+      if (cancelled) return;
+      if (!res.ok) {
+        setError("Failed to load usage");
+        setLoading(false);
+        return;
+      }
+      const data = (await res.json()) as { usage?: UsageData[] };
+      setUsage(data.usage ?? []);
+      setLoading(false);
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center p-12">
+        <Loader2 className="w-8 h-8 animate-spin text-cobalt" />
+      </div>
+    );
+  }
+  if (error) return <p className="p-6 text-sm text-red-500">{error}</p>;
+
+  const formatGB = (bytes: number) => `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+  const totalStorage = usage.reduce((acc, u) => acc + u.storage_bytes, 0);
+  const totalJobs = usage.reduce((acc, u) => acc + u.processing_jobs, 0);
+  const totalProjects = usage.reduce((acc, u) => acc + u.projects_count, 0);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <SummaryStat
+          icon={<HardDrive className="w-4 h-4" />}
+          label="Total Platform Storage"
+          value={formatGB(totalStorage)}
+        />
+        <SummaryStat
+          icon={<ImageIcon className="w-4 h-4" />}
+          label="Total Processing Jobs"
+          value={`${totalJobs.toLocaleString()}`}
+        />
+        <SummaryStat
+          icon={<Cpu className="w-4 h-4" />}
+          label="Total Active Projects"
+          value={`${totalProjects.toLocaleString()}`}
+        />
+      </div>
+
+      <div className="bg-card border border-border rounded-xl overflow-hidden">
+        <div className="p-4 border-b border-border bg-muted/30">
+          <h3 className="font-semibold text-foreground text-sm">Top Organizations by Storage</h3>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-muted/20 border-b border-border text-muted-foreground">
+              <tr>
+                <th className="px-6 py-3 font-medium">Organization</th>
+                <th className="px-6 py-3 font-medium">Storage Used</th>
+                <th className="px-6 py-3 font-medium">% of Limit</th>
+                <th className="px-6 py-3 font-medium">Processing Jobs</th>
+                <th className="px-6 py-3 font-medium">Projects</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {usage.map((u) => (
+                <tr key={u.org_id} className="hover:bg-muted/20">
+                  <td className="px-6 py-4 font-medium text-foreground">{u.org_name}</td>
+                  <td className="px-6 py-4 text-cobalt font-medium">{formatGB(u.storage_bytes)}</td>
+                  <td className="px-6 py-4 text-foreground">
+                    <div className="flex items-center gap-2">
+                      <div className="h-1.5 w-20 bg-muted/40 rounded-full overflow-hidden">
+                        <div
+                          className={`h-full ${
+                            u.storage_percent > 90
+                              ? "bg-red-500"
+                              : u.storage_percent > 70
+                              ? "bg-yellow-500"
+                              : "bg-cobalt"
+                          }`}
+                          style={{ width: `${Math.min(100, u.storage_percent)}%` }}
+                        />
+                      </div>
+                      <span className="text-xs text-muted-foreground">
+                        {u.storage_percent.toFixed(1)}%
+                      </span>
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 text-foreground">{u.processing_jobs}</td>
+                  <td className="px-6 py-4 text-foreground">{u.projects_count}</td>
+                </tr>
+              ))}
+              {usage.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="px-6 py-8 text-center text-muted-foreground">
+                    No usage data available yet.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SummaryStat({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="bg-card border border-border p-6 rounded-xl">
+      <div className="flex items-center gap-3 mb-2 text-muted-foreground">
+        {icon}
+        <span className="text-sm font-medium">{label}</span>
+      </div>
+      <div className="text-3xl font-bold text-foreground">{value}</div>
+    </div>
+  );
+}

--- a/components/dashboard/operations/UserAccountsTab.tsx
+++ b/components/dashboard/operations/UserAccountsTab.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2, Search, Mail, UserX, Eye, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface UserProfile {
+  id: string;
+  email: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  organization_name: string | null;
+  role: string | null;
+  beta_tester: boolean | null;
+  onboarding_completed_at: string | null;
+  created_at: string;
+}
+
+export function UserAccountsTab() {
+  const [users, setUsers] = useState<UserProfile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    const res = await fetch("/api/operations/users");
+    if (!res.ok) {
+      setError("Failed to load user accounts");
+      setLoading(false);
+      return;
+    }
+    const data = (await res.json()) as { users?: UserProfile[] };
+    setUsers(data.users ?? []);
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const filtered = users.filter((u) => {
+    if (!search.trim()) return true;
+    const q = search.toLowerCase();
+    return (
+      (u.email ?? "").toLowerCase().includes(q) ||
+      (u.first_name ?? "").toLowerCase().includes(q) ||
+      (u.last_name ?? "").toLowerCase().includes(q) ||
+      (u.organization_name ?? "").toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3 flex-wrap">
+        <div className="relative flex-1 min-w-[240px]">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by name, email, or organization…"
+            className="w-full bg-card border border-border rounded-lg pl-10 pr-4 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-cobalt/40"
+          />
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {filtered.length} of {users.length}
+        </div>
+        <Button variant="ghost" size="sm" onClick={load} disabled={loading}>
+          <RefreshCw className={`mr-1 h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {loading && users.length === 0 ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-red-800 bg-red-950/30 p-4 text-sm text-red-300">
+          {error}
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="py-12 text-center text-sm text-muted-foreground">
+          No users match this search.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-border bg-card">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="border-b border-border bg-muted/30">
+                <tr>
+                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">User</th>
+                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Organization</th>
+                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Role</th>
+                  <th className="px-4 py-2.5 text-center text-xs font-medium text-muted-foreground">Onboarded</th>
+                  <th className="px-4 py-2.5 text-center text-xs font-medium text-muted-foreground">Beta</th>
+                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Joined</th>
+                  <th className="px-4 py-2.5 text-right text-xs font-medium text-muted-foreground">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {filtered.map((u) => {
+                  const fullName = [u.first_name, u.last_name].filter(Boolean).join(" ").trim();
+                  return (
+                    <tr key={u.id} className="hover:bg-muted/20">
+                      <td className="px-4 py-3">
+                        <div>
+                          <p className="font-medium text-foreground">
+                            {fullName || u.email || u.id.slice(0, 8)}
+                          </p>
+                          {u.email && fullName && (
+                            <p className="text-xs text-muted-foreground">{u.email}</p>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">{u.organization_name ?? "—"}</td>
+                      <td className="px-4 py-3 text-muted-foreground">{u.role ?? "—"}</td>
+                      <td className="px-4 py-3 text-center">
+                        {u.onboarding_completed_at ? (
+                          <span className="inline-flex items-center rounded-full bg-green-900/30 px-2 py-0.5 text-xs font-medium text-green-300">
+                            Yes
+                          </span>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">No</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-center">
+                        {u.beta_tester ? (
+                          <span className="inline-flex items-center rounded-full bg-cobalt/15 px-2 py-0.5 text-xs font-medium text-cobalt">
+                            Beta
+                          </span>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {new Date(u.created_at).toLocaleDateString("en-US", {
+                          month: "short",
+                          day: "numeric",
+                          year: "numeric",
+                        })}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <div className="inline-flex items-center gap-1">
+                          <Button variant="ghost" size="icon" disabled title="Email (Phase 2)">
+                            <Mail className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button variant="ghost" size="icon" disabled title="Suspend (Phase 2)">
+                            <UserX className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button variant="ghost" size="icon" disabled title="View (Phase 2)">
+                            <Eye className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Operations Console Phase 1

Replaces the legacy single-file beta-only Ops Console with a 15-tab enterprise shell. Phase 1 wires up four tabs end-to-end; the remaining 11 render a "Module Under Construction" placeholder until Phase 2.

### What's in this PR

**New shell** — `components/dashboard/operations/OperationsConsoleClient.tsx` (150 lines)
- 15 tabs in horizontal-scrollable nav (mobile/tablet safe via `whitespace-nowrap` + `overflow-x-auto`)
- Dark theme tokens only (`bg-card`, `border-border`, `text-cobalt`, etc.)
- `TabID` union + typed `TabDef` array — no `any`

**Phase 1 tabs (live):**
1. **Overview** — 6 metric cards (total/onboarded/pending-beta users, total/new orgs, new users 7d) → `/api/operations/overview`
2. **Beta Approvals** — extracted from legacy single-file Ops Console; reuses `useBetaUsers` hook against existing `/api/admin/beta`
3. **User Accounts** — searchable table over `profiles` (name/email/org/role/onboarded/beta/joined) → `/api/operations/users`
4. **Organizations** — searchable card grid with member counts/tier/plan/status → `/api/operations/organizations`

**Phase 2 placeholders:** Plans & Pricing, Subscriptions, Revenue, Usage, Content Assets, Communications, Support, Surveys, Employees, Product Ops, Audit Log

**API routes**
- All gated on `resolveServerOrgContext().canAccessOperationsConsole`
- Use `createAdminClient()` for service-role reads (RLS bypass)
- Typed responses, no `any`
- `/api/operations/overview` runs 6 parallel `count: 'exact', head: true` queries

**Page entry** — `app/(dashboard)/operations-console/page.tsx`
- Import switched to new shell path
- Legacy `components/dashboard/OperationsConsoleClient.tsx` left orphaned for one PR cycle (cleanup in follow-up)

### Schema

No migrations needed — all required columns already live (`organizations.tier`, `profiles.onboarding_completed_at`, `profiles.beta_tester`, etc.).

### File sizes (all <300)

| File | Lines |
|---|---|
| `OperationsConsoleClient.tsx` | 150 |
| `BetaApprovalsTab.tsx` | 212 |
| `UserAccountsTab.tsx` | 168 |
| `OrganizationsTab.tsx` | 143 |
| `OverviewTab.tsx` | 118 |
| `api/operations/overview/route.ts` | 67 |
| `api/operations/organizations/route.ts` | 56 |
| `api/operations/users/route.ts` | 29 |

### Validation

- ✅ `npx tsc --noEmit` clean
- ✅ `bash scripts/check-file-size.sh` — no new offenders
- ✅ Auth gated at both page (notFound for non-CEO) and API layer (forbidden response)

### Smoke tests (post-deploy)

1. Visit `/operations-console` as CEO → tabbed UI renders, Overview tab loads metrics
2. Click each Phase 1 tab → data loads, search filters work
3. Beta Approvals: approve/revoke still functions (existing flow)
4. Click any Phase 2 tab → "Module Under Construction" card renders
5. Visit as non-CEO user → 404

### Follow-up (next PR)

- Delete legacy `components/dashboard/OperationsConsoleClient.tsx` once verified
- Phase 2: build out remaining 11 tabs