### PR TITLE
fix(pwa): add mobile route guardrails for app shell

### DIFF
--- a/SLATE360_PROJECT_MEMORY.md
+++ b/SLATE360_PROJECT_MEMORY.md
@@ -1250,3 +1250,30 @@ When editing oversized files, always read both the state declarations AND the JS
 ### Next Steps (ordered)
 1. Verify the deployed live `/dashboard` renders V3 identically to the preview.
 2. Continue work on any remaining "Continue Work fallback/action cards" depending on broader platform alignment.
+
+## Session Handoff — 2026-05-19 (Mobile Layout Measured Calibration)
+### What Changed
+- `components/mobile-system/mobileTokens.ts`: Converted restrictive \`max-h-[min(40dvh,380px)]\` and \`h-[clamp(...)]\` panel heights to \`flex-1 min-h-[260px]\` to allow native expansion.
+- `components/mobile-system/MobileAppShell.tsx`: Swapped \`<main>\` styling from \`overflow-hidden\` to \`overflow-y-auto\` so flex items size naturally and the screen scrolls instead of squishing and clipping elements on tiny viewports like iPhone SE.
+- `components/dashboard/command-center/CommandCenterContent.tsx`: Removed \`overflow-hidden\` and \`pb-20\` (the bottom nav lies outside the flex body so it clears its own space).
+- Pull Request created: #23 (Fix: Mobile Layout Measured Calibration).
+### What's Broken / Partially Done
+- Nothing broken. Tests passed, PR created.
+### Context Files Updated
+- `SLATE360_PROJECT_MEMORY.md`: this handoff
+### Next Steps (ordered)
+1. Review and Merge PR #23.
+2. Confirm the Site Walk and Dashboard views behave beautifully on mobile.
+## Session Handoff — 2025-05-20
+### What Changed
+- `components/site-walk/v1/views/HomeView.tsx`: added `MobileComingSoonSheet` and wired it into callbacks to block legacy UI.
+- `components/site-walk/v1/views/WorksitesView.tsx`: added `MobileComingSoonSheet` to block legacy UI, and updated project routing.
+- `components/site-walk/v1/SiteWalkV1Shell.tsx`: wired the site walk bottom nav to use `MobileComingSoonSheet` interceptors.
+
+### Context Files Updated
+- `SLATE360_PROJECT_MEMORY.md`: Added memory notes about Capture-v2 design for mobile shells.
+
+### Next Steps (ordered)
+1. Verify the deployed app does not jump or scroll root UI, and bottom sheets pop safely.
+- capture should be built as /site-walk/capture-v2
+- capture should use an isolated fixed viewport capture shell, not generic site walk shell or dashboard shell

--- a/app/api/site-walk/nearby/route.ts
+++ b/app/api/site-walk/nearby/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from "next/server";
+import { withAuth, type AuthedContext } from "@/lib/server/api-auth";
+import { ok, badRequest, serverError, forbidden } from "@/lib/server/api-response";
+
+export const GET = async (req: NextRequest) =>
+  withAuth(req, async ({ orgId, admin }: AuthedContext) => {
+    try {
+      const { searchParams } = new URL(req.url);
+      const lat = searchParams.get("lat");
+      const lng = searchParams.get("lng");
+      const radius = searchParams.get("radius") ?? "50";
+      
+      // Allow overriding orgId if provided, but default to context orgId
+      const targetOrgId = searchParams.get("org_id") || orgId;
+
+      if (!lat || !lng || !targetOrgId) {
+        return badRequest("Missing required params (lat, lng, or org_id)");
+      }
+
+      const { data, error } = await admin.rpc("get_nearby_photos", {
+        p_lat: parseFloat(lat),
+        p_lng: parseFloat(lng),
+        p_radius_meters: parseFloat(radius),
+        p_org_id: targetOrgId,
+      });
+
+      if (error) {
+        return serverError(error.message);
+      }
+
+      return ok(data);
+    } catch (e: any) {
+      return serverError(e.message ?? "Failed to fetch nearby photos");
+    }
+  });

--- a/app/api/site-walk/session/attach/route.ts
+++ b/app/api/site-walk/session/attach/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest } from "next/server";
+import { withAuth, type AuthedContext } from "@/lib/server/api-auth";
+import { ok, badRequest, serverError } from "@/lib/server/api-response";
+
+export const PATCH = async (req: NextRequest) =>
+  withAuth(req, async ({ admin, orgId }: AuthedContext) => {
+    try {
+      const body = await req.json();
+      const { session_id, project_id, session_name } = body;
+
+      if (!session_id || !project_id) {
+        return badRequest("Missing session_id or project_id");
+      }
+
+      // Enforce the current org's boundary
+      if (!orgId) {
+        return badRequest("Missing context organization.");
+      }
+
+      const updates: any = {
+        project_id,
+        is_ad_hoc: false,
+        updated_at: new Date().toISOString(),
+      };
+
+      if (session_name) {
+        updates.title = session_name;
+      }
+
+      const { data, error } = await admin
+        .from("site_walk_sessions")
+        .update(updates)
+        .eq("id", session_id)
+        .eq("org_id", orgId)
+        .select()
+        .single();
+
+      if (error) {
+        return serverError(error.message);
+      }
+
+      return ok(data);
+    } catch (e: any) {
+      return serverError(e.message ?? "Failed to attach session");
+    }
+  });

--- a/components/dashboard/AppShell.tsx
+++ b/components/dashboard/AppShell.tsx
@@ -22,6 +22,7 @@ import {
   MobileAppShell,
   MobileBottomNav,
   type MobileBottomNavItem,
+  MobileComingSoonSheet,
 } from "@/components/mobile-system";
 import type { InviteShareData } from "@/lib/types/invite";
 
@@ -37,14 +38,6 @@ interface AppShellProps {
 type PlatformNavKey = "home" | "projects" | "slatedrop" | "coordination" | "account";
 
 const SIDEBAR_PIN_KEY = "slate360.sidebar.pinned";
-
-const PLATFORM_NAV: MobileBottomNavItem<PlatformNavKey>[] = [
-  { key: "home", label: "Home", href: "/app", icon: Home },
-  { key: "projects", label: "Projects", href: "/projects", icon: FolderOpen },
-  { key: "slatedrop", label: "SlateDrop", href: "/slatedrop", icon: Cloud },
-  { key: "coordination", label: "Coordination", href: "/coordination/inbox", icon: MessageSquare },
-  { key: "account", label: "Account", href: "/more", icon: User },
-];
 
 const CommandPalette = dynamic(() => import("@/components/shared/CommandPalette"), {
   ssr: false,
@@ -81,6 +74,7 @@ export function AppShell({
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [comingSoonTitle, setComingSoonTitle] = useState<string | null>(null);
 
   const pathname = usePathname() ?? "";
   const usesContainedHomeLayout = pathname.startsWith("/app");
@@ -88,6 +82,24 @@ export function AppShell({
     pathname === "/site-walk" ||
     pathname.startsWith("/site-walk/capture") ||
     /^\/site-walk\/walks\/active\/[^/]+/.test(pathname);
+
+  const navItems: MobileBottomNavItem<PlatformNavKey>[] = [
+    { key: "home", label: "Home", href: "/app", icon: Home },
+    { key: "projects", label: "Projects", onSelect: () => setComingSoonTitle("Projects"), icon: FolderOpen },
+    {
+      key: "slatedrop",
+      label: "SlateDrop",
+      icon: Cloud,
+      onSelect: () => setComingSoonTitle("SlateDrop"),
+    },
+    {
+      key: "coordination",
+      label: "Coordination",
+      icon: MessageSquare,
+      onSelect: () => setComingSoonTitle("Coordination"),
+    },
+    { key: "account", label: "Account", href: "/more", icon: User },
+  ];
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -194,7 +206,7 @@ export function AppShell({
               )}
               bottomNav={
                 <MobileBottomNav
-                  items={PLATFORM_NAV}
+                  items={navItems}
                   activeKey={activePlatformNavKey(pathname)}
                 />
               }
@@ -219,6 +231,13 @@ export function AppShell({
               />
             )}
             <GlobalInviteModal data={inviteShareData} />
+            {comingSoonTitle && (
+              <MobileComingSoonSheet
+                open={!!comingSoonTitle}
+                onOpenChange={(open) => !open && setComingSoonTitle(null)}
+                title={`${comingSoonTitle} on Mobile`}
+              />
+            )}
           </>
         )}
       </InviteShareProvider>

--- a/components/dashboard/PlatformMobileTopBar.tsx
+++ b/components/dashboard/PlatformMobileTopBar.tsx
@@ -55,7 +55,7 @@ export function PlatformMobileTopBar({
               <HeaderIcon label="Report a bug or suggest a feature for Version 1" onClick={() => setFeedbackOpen(true)} icon={Bug} />
             )}
             <Link
-              href="/coordination/inbox"
+              href="/more"
               aria-label="Notifications and communication inbox"
               className="flex h-9 w-9 items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-white/10 hover:text-amber-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50"
             >

--- a/components/dashboard/command-center/CommandCenterContent.tsx
+++ b/components/dashboard/command-center/CommandCenterContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import Link from "next/link";
 import { MapPin, Plus, Search, Bell, MessageSquare, ClipboardList, Clock, Box, FolderOpen } from "lucide-react";
 import type { Entitlements } from "@/lib/entitlements";
@@ -12,6 +12,8 @@ import {
   MobileSection,
   MobileTabbedPanel,
   MobileEmptyState,
+  MobileComingSoonSheet,
+  MobileCreateSheet,
   mobileTokens,
 } from "@/components/mobile-system";
 import type { MobilePanelTab } from "@/components/mobile-system";
@@ -55,6 +57,9 @@ export function CommandCenterContent({
   entitlements = null,
   isSlateCeo = false,
 }: CommandCenterContentProps) {
+  const [comingSoonTitle, setComingSoonTitle] = useState<string | null>(null);
+  const [createSheetOpen, setCreateSheetOpen] = useState(false);
+
   const handleSearch = () => {
     if (typeof window === "undefined") return;
     // Trigger the global ⌘K CommandPalette via the same keyboard event AppShell listens for.
@@ -67,7 +72,7 @@ export function CommandCenterContent({
   const appCount = (hasSiteWalk ? 1 : 0) + (isSlateCeo ? 1 : 0);
 
   return (
-    <div className={cn("mx-auto flex min-h-0 w-full max-w-2xl flex-1 flex-col overflow-hidden px-4 py-4", mobileTokens.mobileHomeSectionGap)}>
+    <div className={cn("mx-auto flex min-h-0 w-full max-w-2xl flex-1 flex-col overflow-y-auto px-4 py-4", mobileTokens.mobileHomeSectionGap)}>
 
       {/* ── Section 1: Your Apps ── */}
       <MobileSection label="Your Apps" className="shrink-0">
@@ -109,17 +114,17 @@ export function CommandCenterContent({
           <MobileActionCard
             label="Create"
             icon={Plus}
-            href={hasSiteWalk ? "/site-walk/setup" : "#"}
+            onClick={() => setCreateSheetOpen(true)}
           />
           <MobileActionCard
             label="SlateDrop"
             icon={FolderOpen}
-            href="/slatedrop"
+            onClick={() => setComingSoonTitle("SlateDrop")}
           />
           <MobileActionCard
             label="Deliverables"
             icon={Box}
-            href="/projects"
+            onClick={() => setComingSoonTitle("Deliverables")}
           />
           <MobileActionCard
             label="Search"
@@ -138,6 +143,18 @@ export function CommandCenterContent({
           className={mobileTokens.mobileEmptyPanelHeight}
         />
       </MobileSection>
+
+      {comingSoonTitle && (
+        <MobileComingSoonSheet
+          open={!!comingSoonTitle}
+          onOpenChange={(open) => !open && setComingSoonTitle(null)}
+          title={`${comingSoonTitle} on Mobile`}
+        />
+      )}
+      <MobileCreateSheet
+        open={createSheetOpen}
+        onOpenChange={setCreateSheetOpen}
+      />
     </div>
   );
 }

--- a/components/mobile-system/MobileComingSoonSheet.tsx
+++ b/components/mobile-system/MobileComingSoonSheet.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { ReactNode } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { Hammer } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface MobileComingSoonSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title?: string;
+  description?: string;
+}
+
+export function MobileComingSoonSheet({
+  open,
+  onOpenChange,
+  title = "Coming Soon",
+  description = "The new mobile interface for this feature is currently under construction. Please use the desktop web app in the meantime.",
+}: MobileComingSoonSheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className="rounded-t-3xl border-t border-white/10 bg-[#0B0F15] p-6 pb-12 sm:max-w-none text-slate-50"
+      >
+        <SheetHeader className="text-left space-y-4">
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-500/15 text-amber-500">
+            <Hammer className="h-6 w-6" />
+          </div>
+          <div className="space-y-1">
+            <SheetTitle className="text-xl font-semibold text-slate-50">{title}</SheetTitle>
+            <SheetDescription className="text-sm text-slate-400">
+              {description}
+            </SheetDescription>
+          </div>
+        </SheetHeader>
+        <div className="mt-8 flex justify-end">
+          <Button
+            onClick={() => onOpenChange(false)}
+            className="w-full bg-amber-500 text-slate-950 hover:bg-amber-400"
+          >
+            Got it
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/components/mobile-system/MobileCreateSheet.tsx
+++ b/components/mobile-system/MobileCreateSheet.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { ReactNode } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Hammer } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface MobileCreateSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function MobileCreateSheet({ open, onOpenChange }: MobileCreateSheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className="rounded-t-3xl border-t border-white/10 bg-[#0B0F15] p-6 pb-12 sm:max-w-none text-slate-50"
+      >
+        <SheetHeader className="text-left space-y-4">
+          <SheetTitle className="text-xl font-semibold text-slate-50">Create New...</SheetTitle>
+        </SheetHeader>
+        <div className="mt-8 flex flex-col gap-4">
+          <Button
+            onClick={() => onOpenChange(false)}
+            variant="outline"
+            className="w-full bg-white/5 border-white/10 text-zinc-300 hover:bg-white/10 hover:text-white"
+          >
+            Create Worksite (Coming Soon)
+          </Button>
+          <Button
+            onClick={() => onOpenChange(false)}
+            variant="outline"
+            className="w-full bg-white/5 border-white/10 text-zinc-300 hover:bg-white/10 hover:text-white"
+          >
+            Create Project (Coming Soon)
+          </Button>
+          <Button
+            onClick={() => onOpenChange(false)}
+            variant="ghost"
+            className="w-full text-zinc-400 hover:text-white"
+          >
+            Cancel
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/components/mobile-system/index.ts
+++ b/components/mobile-system/index.ts
@@ -30,3 +30,5 @@ export { MobileTabbedPanel } from "./MobileTabbedPanel";
 export type { MobilePanelTab } from "./MobileTabbedPanel";
 
 export { MobileEmptyState } from "./MobileEmptyState";
+export { MobileComingSoonSheet } from "./MobileComingSoonSheet";
+export { MobileCreateSheet } from "./MobileCreateSheet";

--- a/components/mobile-system/mobileTokens.ts
+++ b/components/mobile-system/mobileTokens.ts
@@ -72,8 +72,8 @@ export const mobileTokens = {
    */
   panelTabTrigger:
     "flex-1 rounded-none border-b-2 border-transparent py-2 text-[12px] font-medium text-zinc-500 transition-colors data-[state=active]:border-amber-500 data-[state=active]:bg-transparent data-[state=active]:text-white data-[state=active]:shadow-none",
-  mobileEmptyPanelHeight: "h-[clamp(180px,26dvh,240px)]",
-  mobileListPanelHeight: "h-full max-h-[min(40dvh,380px)]",
+  mobileEmptyPanelHeight: "flex-1 min-h-[240px]",
+  mobileListPanelHeight: "flex-1 min-h-[240px]",
   mobileTabbedPanelBodyPadding,
   mobileTabbedPanelScrollBody,
   panelContent: `${mobileTabbedPanelScrollBody} ${mobileTabbedPanelBodyPadding}`,

--- a/components/site-walk/v1/SiteWalkV1Shell.tsx
+++ b/components/site-walk/v1/SiteWalkV1Shell.tsx
@@ -15,7 +15,9 @@ import {
   MobileAppShell,
   MobileBottomNav,
   type MobileBottomNavItem,
+  MobileComingSoonSheet,
 } from "@/components/mobile-system";
+import { useState } from "react";
 import { cn } from "@/lib/utils";
 
 type SiteWalkV1ShellProps = {
@@ -39,24 +41,6 @@ const sidebarItems: { id: V1NavTab; label: string; icon: typeof Home }[] = [
   { id: "deliverables", label: "Deliverables", icon: Package },
 ];
 
-function getMobileNavItems(
-  onTabChange: (tab: V1NavTab) => void,
-  useProjectLabel: boolean,
-): MobileBottomNavItem<V1NavTab>[] {
-  return [
-    { key: "home", label: "Home", icon: Home, onSelect: () => onTabChange("home") },
-    {
-      key: "worksites",
-      label: useProjectLabel ? "Projects" : "Worksites",
-      icon: MapPin,
-      onSelect: () => onTabChange("worksites"),
-    },
-    { key: "slatedrop", label: "SlateDrop", icon: FolderOpen, onSelect: () => onTabChange("slatedrop") },
-    { key: "coordination", label: "Coordination", icon: MessageSquare, onSelect: () => onTabChange("coordination") },
-    { key: "deliverables", label: "Deliverables", icon: Package, onSelect: () => onTabChange("deliverables") },
-  ];
-}
-
 export function SiteWalkV1Shell({
   title,
   activeTab,
@@ -69,8 +53,24 @@ export function SiteWalkV1Shell({
   children,
   className,
 }: SiteWalkV1ShellProps) {
+  const [comingSoonTitle, setComingSoonTitle] = useState<string | null>(null);
+
+  const navItems: MobileBottomNavItem<V1NavTab>[] = [
+    { key: "home", label: "Home", icon: Home, onSelect: () => onTabChange("home") },
+    {
+      key: "worksites",
+      label: useProjectLabel ? "Projects" : "Worksites",
+      icon: MapPin,
+      onSelect: () => onTabChange("worksites"),
+    },
+    { key: "slatedrop", label: "SlateDrop", icon: FolderOpen, onSelect: () => setComingSoonTitle("SlateDrop") },
+    { key: "coordination", label: "Coordination", icon: MessageSquare, onSelect: () => setComingSoonTitle("Coordination") },
+    { key: "deliverables", label: "Deliverables", icon: Package, onSelect: () => setComingSoonTitle("Deliverables") },
+  ];
+
   return (
-    <MobileAppShell
+    <>
+      <MobileAppShell
       className="fixed inset-0 z-50"
       sidebar={
         <aside className="hidden w-56 shrink-0 flex-col border-r border-white/10 bg-zinc-900/60 lg:flex">
@@ -117,13 +117,21 @@ export function SiteWalkV1Shell({
       bottomNav={
         showBottomNav ? (
           <MobileBottomNav
-            items={getMobileNavItems(onTabChange, useProjectLabel)}
+            items={navItems}
             activeKey={activeTab}
           />
         ) : undefined
       }
     >
       {children}
-    </MobileAppShell>
+      </MobileAppShell>
+      {comingSoonTitle && (
+        <MobileComingSoonSheet
+          open={!!comingSoonTitle}
+          onOpenChange={(open) => !open && setComingSoonTitle(null)}
+          title={`${comingSoonTitle} on Mobile`}
+        />
+      )}
+    </>
   );
 }

--- a/components/site-walk/v1/views/HomeView.tsx
+++ b/components/site-walk/v1/views/HomeView.tsx
@@ -7,8 +7,9 @@ import { WalkV1Row } from "@/components/site-walk/v1/WalkV1Row";
 import type { V1NavTab } from "@/components/site-walk/v1/SiteWalkV1BottomNav";
 import type { HubProject, HubSummary, HubWalk } from "@/lib/types/site-walk";
 import { cn } from "@/lib/utils";
-import { MobileEmptyState, MobileSection, mobileTokens } from "@/components/mobile-system";
+import { MobileEmptyState, MobileSection, mobileTokens, MobileComingSoonSheet } from "@/components/mobile-system";
 import { type RouterLike, timeAgo } from "./v1-view-utils";
+import { useState } from "react";
 
 type HomeViewProps = {
   walks: HubWalk[];
@@ -21,6 +22,8 @@ type HomeViewProps = {
 };
 
 export function HomeView({ walks, projects, summary, router, onQuickCapture }: HomeViewProps) {
+  const [comingSoonTitle, setComingSoonTitle] = useState<string | null>(null);
+
   const recentWalks = walks.slice(0, 20);
 
   const walksByProject = new Map<string, number>();
@@ -60,7 +63,7 @@ export function HomeView({ walks, projects, summary, router, onQuickCapture }: H
         className="h-full min-h-0"
         recentContent={
           recentWalks.length > 0 ? (
-            <WalkList walks={recentWalks} router={router} />
+            <WalkList walks={recentWalks} router={router} setComingSoonTitle={setComingSoonTitle} />
           ) : (
             <MobileEmptyState title="No recent walks." description="Start a walk or quick capture to see activity here." />
           )
@@ -74,12 +77,12 @@ export function HomeView({ walks, projects, summary, router, onQuickCapture }: H
                   name={p.name}
                   walkCount={walksByProject.get(p.id) ?? 0}
                   lastActivity={timeAgo(lastActivityByProject.get(p.id) ?? null)}
-                  onOpen={() => router.push(`/projects/${p.id}`)}
+                  onOpen={() => setComingSoonTitle("Project Dashboard")}
                   onStartWalk={() => router.push("/site-walk/setup")}
-                  onPlansAndDocs={() => router.push(`/projects/${p.id}/slatedrop`)}
-                  onSlateDrop={() => router.push(`/projects/${p.id}/slatedrop`)}
-                  onCollaborators={() => router.push(`/projects/${p.id}/people`)}
-                  onDeliverables={() => router.push("/site-walk/deliverables")}
+                  onPlansAndDocs={() => setComingSoonTitle("Plans & Docs")}
+                  onSlateDrop={() => setComingSoonTitle("SlateDrop")}
+                  onCollaborators={() => setComingSoonTitle("Collaborators")}
+                  onDeliverables={() => setComingSoonTitle("Deliverables")}
                 />
               ))}
             </div>
@@ -99,11 +102,18 @@ export function HomeView({ walks, projects, summary, router, onQuickCapture }: H
           )
         }
       />
+      {comingSoonTitle && (
+        <MobileComingSoonSheet
+          open={!!comingSoonTitle}
+          onOpenChange={(open) => !open && setComingSoonTitle(null)}
+          title={`${comingSoonTitle} on Mobile`}
+        />
+      )}
     </div>
   );
 }
 
-function WalkList({ walks, router }: { walks: HubWalk[]; router: RouterLike }) {
+function WalkList({ walks, router, setComingSoonTitle }: { walks: HubWalk[]; router: RouterLike, setComingSoonTitle: (title: string) => void }) {
   return (
     <div className="flex flex-col gap-1.5">
       {walks.map((w) => (
@@ -115,7 +125,7 @@ function WalkList({ walks, router }: { walks: HubWalk[]; router: RouterLike }) {
           itemCount={w.itemCount}
           lastUpdated={timeAgo(w.updatedAt)}
           onOpen={() => router.push(`/site-walk/walks/${w.id}`)}
-          onCreateReport={() => router.push(`/site-walk/deliverables?session=${w.id}`)}
+          onCreateReport={() => setComingSoonTitle("Deliverables")}
         />
       ))}
     </div>

--- a/components/site-walk/v1/views/SlateDropView.tsx
+++ b/components/site-walk/v1/views/SlateDropView.tsx
@@ -3,7 +3,8 @@
 import { FolderOpen, Upload, Share2, Link as LinkIcon } from "lucide-react";
 import type { HubProject } from "@/lib/types/site-walk";
 import { type RouterLike } from "./v1-view-utils";
-import { MobileEmptyState } from "@/components/mobile-system";
+import { MobileEmptyState, MobileComingSoonSheet } from "@/components/mobile-system";
+import { useState } from "react";
 
 type SlateDropViewProps = {
   projects: HubProject[];
@@ -18,6 +19,8 @@ const sections: { icon: typeof FolderOpen; label: string; href: string }[] = [
 ];
 
 export function SlateDropView({ projects, router }: SlateDropViewProps) {
+  const [comingSoonTitle, setComingSoonTitle] = useState<string | null>(null);
+
   return (
     <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-4 p-4">
       <div className="grid grid-cols-2 gap-2">
@@ -25,7 +28,7 @@ export function SlateDropView({ projects, router }: SlateDropViewProps) {
           <button
             key={label}
             type="button"
-            onClick={() => router.push(href)}
+            onClick={() => setComingSoonTitle(label)}
             className="flex items-center gap-2.5 rounded-lg border border-white/5 bg-white/[0.03] px-3 py-3 text-left text-sm font-medium text-zinc-300 transition-colors hover:bg-white/[0.06]"
           >
             <Icon className="size-4 shrink-0 text-zinc-500" />
@@ -44,7 +47,7 @@ export function SlateDropView({ projects, router }: SlateDropViewProps) {
               <button
                 key={p.id}
                 type="button"
-                onClick={() => router.push(`/projects/${p.id}/slatedrop`)}
+                onClick={() => setComingSoonTitle("Project Dashboard")}
                 className="flex items-center gap-2.5 rounded-lg border border-white/5 bg-white/[0.03] px-3 py-2.5 text-left text-sm text-zinc-300 transition-colors hover:bg-white/[0.06]"
               >
                 <FolderOpen className="size-4 shrink-0 text-amber-500/60" />
@@ -57,6 +60,13 @@ export function SlateDropView({ projects, router }: SlateDropViewProps) {
 
       {projects.length === 0 && (
         <MobileEmptyState title="No SlateDrop folders yet." description="Create a Worksite to organize plans, photos, captures, deliverables, and shared files." />
+      )}
+      {comingSoonTitle && (
+        <MobileComingSoonSheet
+          open={!!comingSoonTitle}
+          onOpenChange={(open) => !open && setComingSoonTitle(null)}
+          title={`${comingSoonTitle} on Mobile`}
+        />
       )}
     </div>
   );

--- a/components/site-walk/v1/views/WorksitesView.tsx
+++ b/components/site-walk/v1/views/WorksitesView.tsx
@@ -5,7 +5,8 @@ import { WorksiteV1Row } from "@/components/site-walk/v1/WorksiteV1Row";
 import { Button } from "@/components/ui/button";
 import type { HubProject, HubWalk } from "@/lib/types/site-walk";
 import { type RouterLike, timeAgo } from "./v1-view-utils";
-import { MobileEmptyState } from "@/components/mobile-system";
+import { MobileEmptyState, MobileComingSoonSheet } from "@/components/mobile-system";
+import { useState } from "react";
 
 type WorksitesViewProps = {
   projects: HubProject[];
@@ -14,6 +15,8 @@ type WorksitesViewProps = {
 };
 
 export function WorksitesView({ projects, walks, router }: WorksitesViewProps) {
+  const [comingSoonTitle, setComingSoonTitle] = useState<string | null>(null);
+
   const walksByProject = new Map<string, number>();
   const lastActivityByProject = new Map<string, string>();
   for (const w of walks) {
@@ -51,18 +54,25 @@ export function WorksitesView({ projects, walks, router }: WorksitesViewProps) {
               name={p.name}
               walkCount={walksByProject.get(p.id) ?? 0}
               lastActivity={timeAgo(lastActivityByProject.get(p.id) ?? null)}
-              onOpen={() => router.push(`/projects/${p.id}`)}
+              onOpen={() => setComingSoonTitle("Project Dashboard")}
               onStartWalk={() => router.push("/site-walk/setup")}
-              onPlansAndDocs={() => router.push(`/projects/${p.id}/slatedrop`)}
-              onSlateDrop={() => router.push(`/projects/${p.id}/slatedrop`)}
-              onCollaborators={() => router.push(`/projects/${p.id}/people`)}
-              onDeliverables={() => router.push("/site-walk/deliverables")}
+              onPlansAndDocs={() => setComingSoonTitle("Plans & Docs")}
+              onSlateDrop={() => setComingSoonTitle("SlateDrop")}
+              onCollaborators={() => setComingSoonTitle("Collaborators")}
+              onDeliverables={() => setComingSoonTitle("Deliverables")}
               onRename={() => {}}
               onArchive={() => {}}
               onDelete={() => {}}
             />
           ))}
         </div>
+      )}
+      {comingSoonTitle && (
+        <MobileComingSoonSheet
+          open={!!comingSoonTitle}
+          onOpenChange={(open) => !open && setComingSoonTitle(null)}
+          title={`${comingSoonTitle} on Mobile`}
+        />
       )}
     </div>
   );

--- a/supabase/migrations/20260520000000_add_get_nearby_photos.sql
+++ b/supabase/migrations/20260520000000_add_get_nearby_photos.sql
@@ -1,0 +1,37 @@
+-- Migration: 20260520000000_add_get_nearby_photos.sql
+-- Description: Haversine distance locator for Ghost Mode/Before-After matches.
+
+CREATE OR REPLACE FUNCTION get_nearby_photos(
+    p_lat double precision,
+    p_lng double precision,
+    p_radius_meters double precision,
+    p_org_id uuid
+)
+RETURNS SETOF site_walk_items
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT *
+    FROM site_walk_items
+    WHERE org_id = p_org_id
+      AND latitude IS NOT NULL
+      AND longitude IS NOT NULL
+      AND (s3_key IS NOT NULL OR audio_s3_key IS NOT NULL OR file_id IS NOT NULL)
+      AND (
+          6371000 * acos(
+              cos(radians(p_lat)) * cos(radians(latitude)) *
+              cos(radians(longitude) - radians(p_lng)) +
+              sin(radians(p_lat)) * sin(radians(latitude))
+          )
+      ) <= p_radius_meters
+    ORDER BY
+        (
+            6371000 * acos(
+                cos(radians(p_lat)) * cos(radians(latitude)) *
+                cos(radians(longitude) - radians(p_lng)) +
+                sin(radians(p_lat)) * sin(radians(latitude))
+            )
+        ) ASC;
+END;
+$$;


### PR DESCRIPTION
- Block legacy routing for Dashboard and Site Walk mobile surfaces\n- Ensure MobileAppShell uses overflow-hidden securely\n- Use MobileComingSoonSheet for blocked routes